### PR TITLE
feat: add update-node-version skill and docs restructure

### DIFF
--- a/.claude/skills/update-node-version/README.md
+++ b/.claude/skills/update-node-version/README.md
@@ -1,0 +1,31 @@
+# update-node-version
+
+A project-local Claude skill that turns a GitHub release URL for a blockchain node into a pull request bumping the matching `docker-<pkg>/build.toml` in this repo. Runs the chain's `sync-config.rs` (if present) to refresh `config/` files, pauses for explicit human confirmation, then commits and opens a PR. Never merges — stops at PR URL.
+
+## Usage
+
+Paste a GitHub release URL in chat, e.g.:
+
+> update bsc to https://github.com/bnb-chain/bsc/releases/tag/v1.7.3
+
+Claude discovers this skill via its frontmatter description and runs the workflow in `SKILL.md`.
+
+## Adding a new mapping
+
+When the skill errors with "No mapping for `<org>/<repo>`", append an entry to `mappings.toml`:
+
+```toml
+[[mapping]]
+repo = "<org>/<repo>"           # from the release URL
+tag_prefix = ""                 # e.g., "op-node/" for optimism monorepo, "celo-" for celo tags
+docker_dir = "docker-<name>"    # target directory in the repo root
+package = "<name>"              # must match [package].name in build.toml
+```
+
+Then re-run the skill. Commit the `mappings.toml` change as a normal `chore` commit.
+
+## Files
+
+- `SKILL.md` — Claude-facing instructions (the workflow).
+- `mappings.toml` — seeded repo → docker-dir table.
+- `README.md` — this file.

--- a/.claude/skills/update-node-version/SKILL.md
+++ b/.claude/skills/update-node-version/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: update-node-version
+description: Use when the user provides a GitHub release URL for a blockchain node and wants to bump the version in this repo. Extracts version, updates docker-<pkg>/build.toml, runs sync-config.rs if present, and opens a PR after user confirmation.
+---
+
+# update-node-version
+
+Given a GitHub release URL like `https://github.com/bnb-chain/bsc/releases/tag/v1.7.3`, bump the matching `docker-<pkg>/build.toml`, sync any chain config, and open a PR. Never merge — stop at PR URL.
+
+## When to use
+
+Invoke this skill when the user pastes (or clearly references) a GitHub release URL for a blockchain node tracked in this repo. Typical phrasings:
+- "update bsc to https://github.com/bnb-chain/bsc/releases/tag/v1.7.3"
+- "new bor release: https://github.com/0xPolygon/bor/releases/tag/v2.7.1"
+- "bump geth https://github.com/ethereum/go-ethereum/releases/tag/v1.17.2"
+
+If the URL does not match `https://github.com/<org>/<repo>/releases/tag/<tag>`, stop and ask the user for a release URL.
+
+## Workflow
+
+Follow these steps in order. Do not skip the human gate.
+
+### 1. Parse the URL
+
+Extract `org`, `repo`, and `tag` from the path. Examples:
+- `https://github.com/bnb-chain/bsc/releases/tag/v1.7.3` → `org=bnb-chain`, `repo=bsc`, `tag=v1.7.3`
+- `https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.12` → `org=ethereum-optimism`, `repo=optimism`, `tag=op-node/v1.16.12`
+
+### 2. Look up the mapping
+
+Read `.claude/skills/update-node-version/mappings.toml`. Among entries where `repo == "<org>/<repo>"`, pick the one whose `tag_prefix` is the **longest** prefix of `tag`. An empty `tag_prefix` matches only when no longer prefix is available for the same repo.
+
+If no entry matches, STOP and print:
+
+```
+No mapping for <org>/<repo>. Add an entry to .claude/skills/update-node-version/mappings.toml:
+
+[[mapping]]
+repo = "<org>/<repo>"
+tag_prefix = "<prefix-or-empty-string>"
+docker_dir = "docker-<name>"
+package = "<name-from-build.toml>"
+```
+
+### 3. Derive the version
+
+Take `tag`, strip the matched `tag_prefix` from the front, then strip a single leading `v` if present. Examples:
+- `tag=v1.7.3`, `tag_prefix=""` → version `1.7.3`
+- `tag=op-node/v1.16.12`, `tag_prefix="op-node/"` → version `1.16.12`
+- `tag=celo-v2.2.2`, `tag_prefix="celo-"` → version `2.2.2`
+- `tag=10.6.3`, `tag_prefix=""` → version `10.6.3`
+
+### 4. Check current state
+
+Read `<docker_dir>/build.toml`. If `[package].version` already equals the new version, STOP with "already at v<version>" — no changes, no branch, no commit.
+
+### 5. Update `build.toml`
+
+Edit `<docker_dir>/build.toml`:
+- Set `[package].version = "<new-version>"`.
+- If the `[package].build` field **currently exists**, set `[package].build = "1"`. If it does not exist, do not add it.
+- If `<org>/<repo> == "ethereum/go-ethereum"` AND `[vars].git_commit` exists in `build.toml`: fetch `https://geth.ethereum.org/downloads`, regex the HTML for `geth-linux-amd64-<version>-([0-9a-f]{8})\.tar\.gz` where `<version>` is the resolved version, and update `[vars].git_commit` to the captured 8-char SHA. If the page fetch fails or the filename is not found, pause and ask the user to paste the 8-char commit SHA; use their response.
+
+Do not touch any other fields in `build.toml`.
+
+### 6. Run sync-config.rs (if present)
+
+If `<docker_dir>/sync-config.rs` exists: run `./sync-config.rs` with the working directory set to `<docker_dir>`. If the script exits non-zero, STOP — print its output and tell the user the working tree is in a partial state; do not commit.
+
+If `sync-config.rs` does not exist: skip silently.
+
+### 7. Show the diff
+
+Run `git status` and `git diff` and display the output to the user so they can review. Summarize what changed in one line (e.g., "Updated bsc-geth from v1.7.2 to v1.7.3; refreshed config/config.toml and config/genesis.json.").
+
+### 8. HUMAN GATE — wait for confirmation
+
+STOP and wait for the user to explicitly confirm. Acceptable confirmations: "yes", "proceed", "ship it", "looks good, commit it", "go ahead".
+
+If the user declines or asks for changes, do not commit. Leave the edits on disk so they can adjust.
+
+Do not commit just because the user says "looks good" without "commit" / "proceed" / "ship" — if it's ambiguous, ask.
+
+### 9. Create branch and commit
+
+Run:
+
+```bash
+git switch -c release/<package>-<version>
+git add <docker_dir>
+git commit -m "$(cat <<'EOF'
+chore(<package>): bump to v<version>
+
+<release-url>
+
+Co-authored-by: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+If `git switch -c` fails because the branch already exists, STOP and ask the user how to proceed (delete the stale branch, or use a different name).
+
+### 10. Push and open the PR
+
+Run:
+
+```bash
+git push -u origin release/<package>-<version>
+gh pr create --title "chore(<package>): bump to v<version>" --body "$(cat <<'EOF'
+<release-url>
+EOF
+)"
+```
+
+Print the PR URL. STOP. Do not merge — per `AGENTS.md`, agents never merge without explicit per-PR confirmation.
+
+## Things to double-check
+
+- The `[package].name` in `build.toml` matches the `package` field in the mapping entry. If it doesn't, the mapping is wrong — fix the mapping, not the build.toml.
+- Only reset `[package].build` to `"1"` if that field already existed in the file.
+- Do not edit `[vars]` for any repo other than `ethereum/go-ethereum`.
+- Do not invent URLs. Only fetch the exact URLs specified: the user-provided release URL and `https://geth.ethereum.org/downloads` for the Ethereum special case.
+- Branch name is `release/<package>-<version>` where `<version>` has no leading `v`.
+- Commit subject includes the `v` prefix: `chore(<package>): bump to v<version>`.

--- a/.claude/skills/update-node-version/mappings.toml
+++ b/.claude/skills/update-node-version/mappings.toml
@@ -1,0 +1,87 @@
+# Mapping from GitHub source repos to docker-* build dirs in this repo.
+# The update-node-version skill reads this file to resolve release URLs.
+#
+# Lookup rule: match on `repo`; among entries with that repo, pick the one
+# whose `tag_prefix` is the longest prefix of the release tag. An empty
+# `tag_prefix` matches any tag with no other prefix entry for the same repo.
+#
+# Each `package` MUST match the [package].name in docker-<dir>/build.toml.
+# Add new entries as you encounter chains not yet listed.
+
+[[mapping]]
+repo = "bnb-chain/bsc"
+tag_prefix = ""
+docker_dir = "docker-bsc-geth"
+package = "bsc-geth"
+
+[[mapping]]
+repo = "0xPolygon/bor"
+tag_prefix = ""
+docker_dir = "docker-bor"
+package = "bor"
+
+[[mapping]]
+repo = "ethereum/go-ethereum"
+tag_prefix = ""
+docker_dir = "docker-geth"
+package = "geth"
+
+[[mapping]]
+repo = "gnosischain/go-ethereum"
+tag_prefix = ""
+docker_dir = "docker-gnosis-geth"
+package = "gnosis-geth"
+
+[[mapping]]
+repo = "ethereum-optimism/optimism"
+tag_prefix = "op-node/"
+docker_dir = "docker-op-node"
+package = "op-node"
+
+[[mapping]]
+repo = "ethereum-optimism/op-geth"
+tag_prefix = ""
+docker_dir = "docker-op-geth"
+package = "op-geth"
+
+[[mapping]]
+repo = "berachain/bera-reth"
+tag_prefix = ""
+docker_dir = "docker-bera-reth"
+package = "bera-reth"
+
+[[mapping]]
+repo = "berachain/beacon-kit"
+tag_prefix = ""
+docker_dir = "docker-beacon-kit"
+package = "beacon-kit"
+
+[[mapping]]
+repo = "IntersectMBO/cardano-node"
+tag_prefix = ""
+docker_dir = "docker-cardano-node"
+package = "cardano-node"
+
+[[mapping]]
+repo = "ava-labs/avalanchego"
+tag_prefix = ""
+docker_dir = "docker-avalanchego"
+package = "avalanchego"
+
+[[mapping]]
+repo = "sigp/lighthouse"
+tag_prefix = ""
+docker_dir = "docker-lighthouse"
+package = "lighthouse"
+
+[[mapping]]
+repo = "OffchainLabs/nitro"
+tag_prefix = ""
+docker_dir = "docker-arbitrum"
+package = "arbitrum"
+
+[[mapping]]
+repo = "celo-org/op-geth"
+tag_prefix = "celo-"
+docker_dir = "docker-celo-op-geth"
+package = "celo-op-geth"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,15 +16,35 @@ If you are uncertain whether authorization applies to the PR in front of you, as
 
 ## Commit Attribution (agent-only)
 
-Every commit created by an AI agent in this repository must include **exactly one** `Co-authored-by` trailer identifying the agent that made the commit. The trailer identifies the **agent tool**, not the underlying model — never stack multiple agent trailers on one commit.
+Every commit created by an AI agent in this repository must include **exactly one** `Co-authored-by` trailer identifying the agent that made the commit. The trailer identifies the **agent tool**, not the underlying model — **never stack multiple agent trailers on one commit** (for example, an Amp-generated commit must not also carry `Co-authored-by: Claude` or `Co-authored-by: Codex` just because Amp used one of those vendors' models under the hood).
 
-For Claude Code:
+Until the listed agents emit their trailers automatically, the trailer must be added by hand when creating or amending the commit.
 
-```text
-Co-authored-by: Claude <noreply@anthropic.com>
-```
+**Trailers by agent:**
 
-See [COMMITS.md](COMMITS.md) for the trailer rules and the repo's commit-message format.
+- **Claude** (Claude Code CLI, or any Claude-API coding agent used directly):
+
+  ```text
+  Co-authored-by: Claude <noreply@anthropic.com>
+  ```
+
+- **Codex** (OpenAI Codex CLI):
+
+  ```text
+  Co-authored-by: Codex <codex@openai.com>
+  ```
+
+- **Amp** (Sourcegraph Amp, regardless of underlying model):
+
+  ```text
+  Co-authored-by: Amp <amp@ampcode.com>
+  ```
+
+Amp may additionally emit an `Amp-Thread-ID:` metadata trailer; that is acceptable alongside the single `Co-authored-by: Amp` trailer because the thread ID identifies the conversation, not a second agent.
+
+If you are uncertain which agent is creating the commit, ask — the trailer is how the operator tracks which agent produced which change, and wrong attribution is worse than no attribution.
+
+See [COMMITS.md](COMMITS.md) for the repo's commit-message format.
 
 ## CLI option ordering (shared)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,40 @@
-# Repository Instructions
+# AGENTS.md
 
-- Keep CLI arguments, flags, and similar option lists sorted consistently whenever order does not affect behavior. This applies to node launcher scripts and comparable config sections so differences between nodes stay easy to scan and compare. Do not reorder positional arguments, subcommands, or any options whose order is semantically significant.
+This repository uses `main` as its primary branch. This file is the canonical home for rules and restrictions that apply only to AI agents. Rules that apply equally to human contributors and agents live in topic-specific files linked under **Shared conventions** below.
+
+## Pull Request Merging (agent-only)
+
+**Agents must never merge a pull request without explicit per-PR confirmation from the human operator.**
+
+- Open the PR, share the URL, and stop. The default response after creating a PR is "PR URL — ready for your review" — not a merge command in the same turn.
+- Prior "just do it" / "don't wait for me" / "proceed autonomously" authorizations apply only to the specific workstream the operator was discussing when they issued them. They do not carry forward to later PRs in the same session or to new sessions. Treat each PR as a fresh approval gate.
+- `--admin` / branch-protection bypass is a privilege, not a default. Use it only when the operator explicitly authorizes merging *this specific PR*.
+- Phrasing that does NOT authorize merge (ask anyway): "proceed", "don't wait for me", "looks good". Phrasing that does: "merge it", "merge this one", "you can merge now", "ship it".
+- Bounded authorization: if the operator says "merge all the PRs we just discussed", merge only the named set — not unrelated PRs that exist or that you open later.
+
+If you are uncertain whether authorization applies to the PR in front of you, ask. The cost of pausing is ~30 seconds; the cost of merging something the operator wasn't ready for is much higher.
+
+## Commit Attribution (agent-only)
+
+Every commit created by an AI agent in this repository must include **exactly one** `Co-authored-by` trailer identifying the agent that made the commit. The trailer identifies the **agent tool**, not the underlying model — never stack multiple agent trailers on one commit.
+
+For Claude Code:
+
+```text
+Co-authored-by: Claude <noreply@anthropic.com>
+```
+
+See [COMMITS.md](COMMITS.md) for the trailer rules and the repo's commit-message format.
+
+## CLI option ordering (shared)
+
+Keep CLI arguments, flags, and similar option lists sorted consistently whenever order does not affect behavior. This applies to node launcher scripts and comparable config sections so differences between nodes stay easy to scan and compare. Do not reorder positional arguments, subcommands, or any options whose order is semantically significant.
+
+## Shared conventions
+
+Rules in the files below apply to everyone working in the repo — human and agent:
+
+- [RULES.md](RULES.md) — documentation-location convention (no project rules in tool-specific files).
+- [BRANCHING.md](BRANCHING.md) — branch naming, feature-branch policy, what never to commit to `main`.
+- [COMMITS.md](COMMITS.md) — Conventional Commits format and agent-attribution trailer.
+- [BUILD_SYSTEM.md](BUILD_SYSTEM.md) — Rust-based Docker build system: `build.toml` schema, `just build <pkg>`, tag formats.

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -1,0 +1,29 @@
+# Branching
+
+## Base branch
+
+`main` is the base branch. All work lands on `main` through pull requests.
+
+**Never commit directly to `main`.** Every change — including small fixes and version bumps — goes through a feature branch and a PR.
+
+## Branch naming
+
+| Purpose | Pattern | Example |
+|---|---|---|
+| Version bumps (upstream releases) | `release/<package>-<version>` | `release/bsc-geth-1.7.3` |
+| New features | `feat-<short-desc>` or `feat/<short-desc>` | `feat-unify-dockerfiles` |
+| Bug fixes | `fix-<short-desc>` | `fix-ci-rust-script-cache` |
+| Maintenance / chores | `chore-<short-desc>` | `chore-bump-clap` |
+| Renovate-generated | `renovate/...` (managed automatically) | `renovate/chainargos-bor-2.x` |
+
+`<package>` in a release branch matches the `[package].name` in the target `build.toml`. `<version>` is the upstream version without a leading `v`.
+
+## Pull requests
+
+- PR titles use [Conventional Commits](COMMITS.md) — the title becomes the squash commit subject.
+- PRs need at least one reviewer (or explicit operator approval for self-merge).
+- Agents do not merge PRs without explicit per-PR confirmation from the operator (see [AGENTS.md](AGENTS.md)).
+
+## Force-push
+
+Force-push (`--force-with-lease`) is allowed on feature branches you own, and only on feature branches. Never force-push `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-See [AGENTS.md](./AGENTS.md).
+@AGENTS.md

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,0 +1,48 @@
+# Commits
+
+This file covers commit message format and agent attribution. Both apply to every commit in this repository.
+
+## Commit Messages
+
+All commits MUST follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Subject format: `<type>[optional scope][!]: <description>`
+
+Allowed types:
+
+| Type | Use for |
+|---|---|
+| `feat` | New user-visible feature |
+| `fix` | Bug fix |
+| `docs` | Documentation-only change |
+| `style` | Formatting, whitespace; no logic change |
+| `refactor` | Internal restructuring; no behavior change |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests |
+| `build` | Build system, tooling, dependencies |
+| `ci` | CI configuration |
+| `chore` | Routine maintenance (release, merge, deps) |
+| `revert` | Reverts a prior commit |
+
+Scope is optional but encouraged when it clarifies the change area, e.g., `chore(bsc-geth): bump to v1.7.3` or `fix(docker-build): handle missing platforms`.
+
+Breaking changes use `!` after the type/scope (`feat!:` or `feat(api)!:`) and include a `BREAKING CHANGE:` footer in the body.
+
+PR squash-merge: the PR title becomes the commit subject, so PR titles must also follow this convention.
+
+## Agent Attribution
+
+Every commit created by an AI agent MUST include exactly one `Co-authored-by` trailer identifying the agent. The trailer identifies the **agent tool**, not the underlying model. Never stack multiple agent trailers on one commit.
+
+For Claude Code (or any Claude-API-driven coding agent used directly):
+
+```text
+Co-authored-by: Claude <noreply@anthropic.com>
+```
+
+If you are uncertain which agent is creating the commit, ask — wrong attribution is worse than no attribution.
+
+## What this repo does NOT require
+
+- **No DCO sign-off.** `git commit -s` is not needed.
+- **No mandatory pre-commit test runs.** This repo is a collection of Rust scripts (`*.rs` via `rust-script`) and Docker assets; run `cargo fmt` and `cargo clippy` when you've modified Rust code, but they are not gates on every commit.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -34,13 +34,29 @@ PR squash-merge: the PR title becomes the commit subject, so PR titles must also
 
 Every commit created by an AI agent MUST include exactly one `Co-authored-by` trailer identifying the agent. The trailer identifies the **agent tool**, not the underlying model. Never stack multiple agent trailers on one commit.
 
-For Claude Code (or any Claude-API-driven coding agent used directly):
+Trailers per agent:
 
-```text
-Co-authored-by: Claude <noreply@anthropic.com>
-```
+- **Claude** (Claude Code CLI, or any Claude-API coding agent used directly):
 
-If you are uncertain which agent is creating the commit, ask — wrong attribution is worse than no attribution.
+  ```text
+  Co-authored-by: Claude <noreply@anthropic.com>
+  ```
+
+- **Codex** (OpenAI Codex CLI):
+
+  ```text
+  Co-authored-by: Codex <codex@openai.com>
+  ```
+
+- **Amp** (Sourcegraph Amp, regardless of underlying model):
+
+  ```text
+  Co-authored-by: Amp <amp@ampcode.com>
+  ```
+
+Amp may additionally emit an `Amp-Thread-ID:` metadata trailer; that is acceptable alongside the single `Co-authored-by: Amp` trailer because the thread ID identifies the conversation, not a second agent.
+
+See [AGENTS.md](AGENTS.md) for the agent-attribution rule and its rationale. If you are uncertain which agent is creating the commit, ask — wrong attribution is worse than no attribution.
 
 ## What this repo does NOT require
 

--- a/RULES.md
+++ b/RULES.md
@@ -1,0 +1,9 @@
+# Rules
+
+## Documentation Convention
+
+All project rules, conventions, commands, and architecture info must live in this repo's topic-specific rule files (linked from [AGENTS.md](AGENTS.md)) — never in tool-specific config files (e.g., `CLAUDE.md`, `GEMINI.md`, `COPILOT.md`).
+
+Tool-specific files should only contain a reference to `AGENTS.md` (e.g., `@AGENTS.md`).
+
+This ensures instructions are shared across all AI agents regardless of which tool is used.


### PR DESCRIPTION
## Summary

Adds a project-local Claude skill (`.claude/skills/update-node-version/`) that turns a GitHub release URL for a blockchain node into a PR bumping the matching `docker-<pkg>/build.toml`. The skill:

- Parses the release URL and resolves the target directory via a seeded `mappings.toml` (13 repos).
- Updates `[package].version`, resets `[package].build` to `"1"` when present, and updates `[vars].git_commit` for the `ethereum/go-ethereum` special case.
- Runs `<docker_dir>/sync-config.rs` when present.
- Pauses for explicit human confirmation before committing.
- Opens a PR and stops — never merges (per `AGENTS.md`).

Also adopts a trimmed jackin-project documentation layout:

- `AGENTS.md` — canonical rules home (agent-only PR-merge gate + commit attribution).
- `CLAUDE.md` — now just `@AGENTS.md`.
- New `RULES.md`, `BRANCHING.md`, `COMMITS.md` — shared conventions.

No DCO sign-off and no mandatory pre-commit test runs in this repo (explicit in `COMMITS.md`).

## Test plan

- [ ] \`python3 -c "import tomllib; tomllib.load(open('.claude/skills/update-node-version/mappings.toml','rb'))"\` parses clean
- [ ] All 13 mapping entries match the corresponding \`docker-*/build.toml\`
- [ ] \`AGENTS.md\` links to \`RULES.md\`, \`BRANCHING.md\`, \`COMMITS.md\`, \`BUILD_SYSTEM.md\`
- [ ] \`CLAUDE.md\` contains only \`@AGENTS.md\`
- [ ] Real-world run of the skill against a fresh release (manual smoke test — separate PR)