### PR TITLE
chore(renovate): enable semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "platformAutomerge": true,
   "prHourlyLimit": 0,
   "prConcurrentLimit": 20,
+  "semanticCommits": "enabled",
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## Summary

Force Renovate PR titles to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) as required by [COMMITS.md](../blob/main/COMMITS.md).

## Why

Renovate's auto-detection produced non-conforming titles like [#509](https://github.com/ChainArgos/blockchain-nodes/pull/509):

> `Update chainargos/beacon-kit Docker tag to v1.3.9`

Since PRs are squash-merged, that title becomes the commit subject on `main`, violating the Conventional Commits rule in COMMITS.md.

## Change

Add `"semanticCommits": "enabled"` to `renovate.json`. Renovate will now prefix titles with `chore(deps):`, producing e.g.:

> `chore(deps): update chainargos/beacon-kit docker tag to v1.3.9`

which matches the `chore | Routine maintenance (release, merge, deps)` row in COMMITS.md.

## What was intentionally NOT copied from jackin's renovate.json

- `commitBody: "Signed-off-by: Renovate Bot ..."` — this repo does not require DCO sign-off (see COMMITS.md "What this repo does NOT require").
- `RENOVATE_GIT_AUTHOR` env in the workflow — same reason.

## Test plan

- [ ] Next Renovate run opens a PR with a `chore(deps):` prefixed title.
- [ ] Existing open Renovate PR #509 can be closed or re-opened to pick up the new convention.