### PR TITLE
chore(cardano-node): bump to v10.7.1

### DIFF
--- a/docker-cardano-node/build.toml
+++ b/docker-cardano-node/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-node"
-version = "10.6.3"
+version = "10.7.1"
 build = "1"
 
 [docker]


### PR DESCRIPTION
https://github.com/IntersectMBO/cardano-node/releases/tag/10.7.1