### PR TITLE
chore(gnosis-geth): bump to v1.17.2-gc

### DIFF
--- a/docker-gnosis-geth/build.toml
+++ b/docker-gnosis-geth/build.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gnosis-geth"
-version = "1.17.1-gc.3"
-build = "2"
+version = "1.17.2-gc"
+build = "1"
 
 [docker]
 repository = "chainargos/gnosis-geth"


### PR DESCRIPTION
https://github.com/gnosischain/go-ethereum/releases/tag/v1.17.2-gc