### PR TITLE
ci(build): serialize per-package builds with concurrency group

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: build-${{ inputs.package }}
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Add a per-package [concurrency group](https://docs.github.com/en/actions/using-jobs/using-concurrency) to the reusable `build-image.yml` job so overlapping pushes to `main` no longer race the same package.

## Problem

Every push to `main` triggers `Build And Publish All`, which fans out ~35 parallel package jobs. When two runs overlap (e.g., back-to-back merges), the second run's exists-check can fire before the first run has pushed its image, leading to duplicate builds of the same package across runs.

## Fix

Add to `build-image.yml`:

```yaml
jobs:
  build:
    concurrency:
      group: build-${{ inputs.package }}
      cancel-in-progress: false
```

- Only same-package jobs queue behind each other. Different packages across overlapping runs still run in parallel.
- `cancel-in-progress: false` — release builds queue rather than cancel. GitHub's concurrency model keeps at most 1 running + 1 pending per group, so rapid-fire pushes naturally coalesce.
- Cooperates with the existing `check-image` step at `build-image.yml:42-51` — when run B's per-package job finally runs after run A, the exists-check sees the image is already on Docker Hub and short-circuits the build/login/buildx steps. No duplicate build, no changes needed to the exists logic.

## Test plan

- [ ] Merge and push a no-op commit that doesn't change any `build.toml`. Confirm all package jobs short-circuit via exists-check (existing behavior preserved).
- [ ] Merge two PRs close together that both bump the same package to different versions. Confirm the second build waits for the first (check "queued" status) rather than racing.
- [ ] Merge two PRs close together that bump *different* packages. Confirm they build in parallel (nothing blocks across different package names).