### PR TITLE
fix(gnosis-geth): update docker-compose to v1.17.2-gc and pin digest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -298,7 +298,7 @@ services:
       - ${FRAXTAL_ROOT_DIR:-~}/fraxtal:/data
 
   gnosis-geth:
-    image: chainargos/gnosis-geth:1.16.7-gc.4-1
+    image: chainargos/gnosis-geth:1.17.2-gc-1@sha256:7e7ef85763aa699abec8ef2b0879faafd01dd0d3e850a1e90319d1a1a41a0157
     container_name: gnosis-geth
     restart: unless-stopped
     stop_grace_period: 15m


### PR DESCRIPTION
## Summary

- `build.toml` was bumped to `v1.17.2-gc` in #514 and the image was successfully pushed to Docker Hub, but `docker-compose.yml` was never updated — leaving the server pointing at `1.16.7-gc.4-1` which no longer exists
- Also adds the missing `@sha256` digest pin (gnosis-geth was the only image in docker-compose.yml without one), which is why Renovate didn't catch this: it tracks updates via digest pinning and couldn't monitor an unpinned entry

## Test plan
- [ ] `just restart-gnosis-geth` succeeds after merge
- [ ] Renovate creates future digest-update PRs for gnosis-geth