### PR TITLE
fix(lighthouse): switch Ethereum checkpoint sync URL to beaconstate.ethstaking.io

### DIFF
--- a/docker-lighthouse/start.sh
+++ b/docker-lighthouse/start.sh
@@ -33,7 +33,7 @@ case $CA_NETWORK in
     exec lighthouse \
       beacon_node \
       --checkpoint-sync-url-timeout=300 \
-      --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+      --checkpoint-sync-url=https://beaconstate.ethstaking.io \
       --datadir=/data/lighthouse \
       --execution-endpoint=http://"${ca_op_geth_hostname}":8551 \
       --execution-jwt=/data/jwtsecret.hex \


### PR DESCRIPTION
## Summary

`mainnet.checkpoint.sigp.io` is timing out from the server (5 min timeout, 3 retries, all failing) — the domain appears unreachable from pegasus while being accessible externally.

Switching to `https://beaconstate.ethstaking.io` which is a widely-used, reliable alternative maintained by EthStaking.

## Test plan
- [ ] `just restart-ethereum-lighthouse` after merge — checkpoint sync completes instead of timing out