### PR TITLE
feat(lighthouse): make checkpoint sync URL configurable via env

### DIFF
--- a/containers.env.sample
+++ b/containers.env.sample
@@ -2,3 +2,10 @@ CA_ETHEREUM_RPC_URL=http://ethereum-geth:8545
 CA_ETHEREUM_EXECUTION_URL=http://ethereum-geth:8551
 CA_ETHEREUM_BEACON_URL=http://ethereum-lighthouse:5052
 CA_ETHEREUM_BEACON_ARCHIVER_URL=http://ethereum-lighthouse:5052
+
+# Optional override for the lighthouse `--checkpoint-sync-url` flag. Set per
+# lighthouse container (e.g. in containers-ethereum.env / containers-gnosis.env).
+# Defaults: ethereum -> https://beaconstate.ethstaker.cc,
+#           gnosis   -> https://checkpoint.gnosischain.com.
+# Public mainnet endpoints: https://eth-clients.github.io/checkpoint-sync-endpoints/
+#CA_LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://beaconstate.ethstaker.cc

--- a/docker-lighthouse/build.toml
+++ b/docker-lighthouse/build.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lighthouse"
 version = "8.1.3"
-build = "2"
+build = "3"
 
 [docker]
 repository = "chainargos/lighthouse"

--- a/docker-lighthouse/start.sh
+++ b/docker-lighthouse/start.sh
@@ -9,10 +9,12 @@ fi
 case $CA_NETWORK in
   ethereum)
     export ca_op_geth_hostname="ethereum-geth"
+    : "${CA_LIGHTHOUSE_CHECKPOINT_SYNC_URL:=https://beaconstate.ethstaker.cc}"
     ;;
 
   gnosis)
     export ca_op_geth_hostname="gnosis-geth"
+    : "${CA_LIGHTHOUSE_CHECKPOINT_SYNC_URL:=https://checkpoint.gnosischain.com}"
     ;;
 
   *)
@@ -33,7 +35,7 @@ case $CA_NETWORK in
     exec lighthouse \
       beacon_node \
       --checkpoint-sync-url-timeout=300 \
-      --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+      --checkpoint-sync-url="${CA_LIGHTHOUSE_CHECKPOINT_SYNC_URL}" \
       --datadir=/data/lighthouse \
       --execution-endpoint=http://"${ca_op_geth_hostname}":8551 \
       --execution-jwt=/data/jwtsecret.hex \
@@ -49,7 +51,7 @@ case $CA_NETWORK in
     exec lighthouse \
       beacon_node \
       --checkpoint-sync-url-timeout=300 \
-      --checkpoint-sync-url=https://checkpoint.gnosischain.com \
+      --checkpoint-sync-url="${CA_LIGHTHOUSE_CHECKPOINT_SYNC_URL}" \
       --datadir=/data/lighthouse \
       --execution-endpoint=http://"${ca_op_geth_hostname}":8551 \
       --execution-jwt=/data/jwtsecret.hex \


### PR DESCRIPTION
## Summary

- Introduce `CA_LIGHTHOUSE_CHECKPOINT_SYNC_URL` to override Lighthouse's `--checkpoint-sync-url` per container, with sensible per-network defaults (`ethereum` → `https://beaconstate.ethstaker.cc`, `gnosis` → existing `https://checkpoint.gnosischain.com`).
- Replace the previous mainnet default (`https://mainnet.checkpoint.sigp.io`), which currently throttles at ~0.7 MB/s from Hetzner and causes the 5-minute `--checkpoint-sync-url-timeout` to fire before the ~325 MB finalized state finishes downloading.
- Bump `docker-lighthouse` build revision to `8.1.3-3` and document the override in `containers.env.sample`.

### Why

The `ethereum-lighthouse` container on `pegasus` has been crash-looping at startup with:

```
CRIT  Failed to start beacon node  reason: "Error loading checkpoint state from remote: HttpClient(, kind: timeout, detail: request or response body error)"
```

Probing the official mainnet endpoints (`https://eth-clients.github.io/checkpoint-sync-endpoints/`) for full finalized-state download speed from inside the container on `pegasus`:

| Operator | URL | Speed | Time to full state |
|---|---|---|---|
| Stakely | `mainnet-checkpoint-sync.stakely.io` | 42 MB/s | 7.7 s |
| **EthStaker** | `beaconstate.ethstaker.cc` | **26 MB/s** | **12.4 s** |
| beaconcha.in | `sync-mainnet.beaconcha.in` | 14 MB/s | 23.0 s |
| BeaconState.info | `beaconstate.info` | 11 MB/s | 29.6 s |
| PietjePuk | `checkpointz.pietjepuk.net` | 3.8 MB/s | timed out @60 s |
| ChainSafe | `beaconstate-mainnet.chainsafe.io` | 2.2 MB/s | timed out @60 s |
| Attestant | `mainnet-checkpoint-sync.attestant.io` | 1.9 MB/s | timed out @60 s |
| Sigma Prime (current) | `mainnet.checkpoint.sigp.io` | 0.7 MB/s | timed out @60 s |

`beaconstate.ethstaker.cc` is the chosen default: well above the 5-minute timeout budget, run by the EthStaker community, and called out as a recommended public endpoint in the official sigp registry. Operators that want a different endpoint can set `CA_LIGHTHOUSE_CHECKPOINT_SYNC_URL` in `containers-ethereum.env` / `containers-gnosis.env` (already wired into `docker-compose.yml` as optional env files).

The same probe from a non-Hetzner host shows `mainnet.checkpoint.sigp.io` at 20 MB/s, so the issue is upstream peering between Hetzner and Sigma Prime's CDN, not a configuration problem on our side.

## Test plan

- [ ] `just build lighthouse` produces `chainargos/lighthouse:8.1.3-3`.
- [ ] Pull/run the new image with `CA_NETWORK=ethereum` and no override → checkpoint sync completes against `beaconstate.ethstaker.cc` (state download well under 300 s).
- [ ] Set `CA_LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet-checkpoint-sync.stakely.io` in `containers-ethereum.env` → Lighthouse log shows `remote_url: https://mainnet-checkpoint-sync.stakely.io/` and sync completes.
- [ ] Run with `CA_NETWORK=gnosis` and no override → checkpoint sync still uses `https://checkpoint.gnosischain.com` (unchanged behavior).
- [ ] `docker-compose.yml` digest pin will be updated in a follow-up after the new image is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude <noreply@anthropic.com>