### PR TITLE
chore(lighthouse): bump chainargos/lighthouse to 8.1.3-3 and pin digest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,7 +248,7 @@ services:
       - ${ETHEREUM_ROOT_DIR:-~}/ethereum:/data
 
   ethereum-lighthouse:
-    image: chainargos/lighthouse:8.1.3-1@sha256:a5bff2fee23ba432f9f19a45d7badba0dcc2fc83a15ebba245808363c663b7ba
+    image: chainargos/lighthouse:8.1.3-3@sha256:bb7a1f4627419c8e9ef6501bd6d116eb142e973f83d8204cc4e5f8e502cc4e21
     container_name: ethereum-lighthouse
     restart: unless-stopped
     stop_grace_period: 15m
@@ -315,7 +315,7 @@ services:
       - ${GNOSIS_ROOT_DIR:-~}/gnosis:/data
 
   gnosis-lighthouse:
-    image: chainargos/lighthouse:8.1.3-1@sha256:a5bff2fee23ba432f9f19a45d7badba0dcc2fc83a15ebba245808363c663b7ba
+    image: chainargos/lighthouse:8.1.3-3@sha256:bb7a1f4627419c8e9ef6501bd6d116eb142e973f83d8204cc4e5f8e502cc4e21
     container_name: gnosis-lighthouse
     restart: unless-stopped
     stop_grace_period: 15m


### PR DESCRIPTION
## Summary

- Bump `chainargos/lighthouse` from `8.1.3-1` to `8.1.3-3` and pin the new digest in `docker-compose.yml` for both `ethereum-lighthouse` and `gnosis-lighthouse`.
- Rolls out the image built from #523, which replaces the failing `mainnet.checkpoint.sigp.io` default with `beaconstate.ethstaker.cc` and exposes `CA_LIGHTHOUSE_CHECKPOINT_SYNC_URL` for per-container overrides.

### Why open this by hand

Renovate ran after #523 merged and reported `"updates": []` for `chainargos/lighthouse` because the default `versioning: docker` scheme treats `8.1.3-1` / `8.1.3-2` / `8.1.3-3` as the same base version `8.1.3` with non-semver build suffixes. Build-revision-only bumps in this repo have always been opened manually for the same reason.

New digest captured directly from Docker Hub: `sha256:bb7a1f4627419c8e9ef6501bd6d116eb142e973f83d8204cc4e5f8e502cc4e21` (published 2026-04-27 21:53:49 UTC by run 25012120543).

## Test plan

- [ ] On pegasus: `docker compose pull ethereum-lighthouse gnosis-lighthouse && docker compose up -d ethereum-lighthouse gnosis-lighthouse`
- [ ] `ethereum-lighthouse` log shows `Starting checkpoint sync remote_url: https://beaconstate.ethstaker.cc/` and reaches `Beacon chain initialised` within 5 minutes (no `Failed to start beacon node` timeout).
- [ ] `gnosis-lighthouse` continues to use `https://checkpoint.gnosischain.com/` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude <noreply@anthropic.com>