### PR TITLE
chore(heimdall): bump to v0.7.1

### DIFF
--- a/.node-updates/approved-config-overrides/heimdall.toml
+++ b/.node-updates/approved-config-overrides/heimdall.toml
@@ -1,0 +1,38 @@
+# Approved local overrides for sync-config output in docker-heimdall.
+#
+# Each entry captures a reviewed upstream value and the approved local value
+# that should be restored after running docker-heimdall/sync-config.rs.
+# If a future sync produces a different upstream value for one of these keys,
+# that change should be shown to the user for review.
+
+package = "heimdall"
+docker_dir = "docker-heimdall"
+reviewed_on = "2026-05-02"
+
+[[override]]
+file = "config/app.toml"
+key = "eth_rpc_url"
+reviewed_upstream_value = "http://localhost:9545"
+approved_value = "http://ethereum-geth:8545"
+reason = "Point at the container-network Ethereum execution client endpoint."
+
+[[override]]
+file = "config/app.toml"
+key = "bor_rpc_url"
+reviewed_upstream_value = "http://localhost:8545"
+approved_value = "http://polygon-bor:8945"
+reason = "Point at the container-network Bor RPC endpoint."
+
+[[override]]
+file = "config/config.toml"
+key = "p2p.seeds"
+reviewed_upstream_value = ""
+approved_value = "7f3049e88ac7f820fd86d9120506aaec0dc54b27@34.89.75.187:26656,2d5484feef4257e56ece025633a6ea132d8cadca@35.246.99.203:26656,72a83490309f9f63fdca3a0bef16c290e5cbb09c@35.246.95.65:26656,00677b1b2c6282fb060b7bb6e9cc7d2d05cdd599@34.105.180.11:26656,721dd4cebfc4b78760c7ee5d7b1b44d29a0aa854@34.147.169.102:26656,4760b3fc04648522a0bcb2d96a10aadee141ee89@34.89.55.74:26656"
+reason = "Polygon mainnet heimdall-v2 seed nodes."
+
+[[override]]
+file = "config/config.toml"
+key = "p2p.persistent_peers"
+reviewed_upstream_value = ""
+approved_value = "7f3049e88ac7f820fd86d9120506aaec0dc54b27@34.89.75.187:26656,2d5484feef4257e56ece025633a6ea132d8cadca@35.246.99.203:26656,72a83490309f9f63fdca3a0bef16c290e5cbb09c@35.246.95.65:26656,00677b1b2c6282fb060b7bb6e9cc7d2d05cdd599@34.105.180.11:26656,721dd4cebfc4b78760c7ee5d7b1b44d29a0aa854@34.147.169.102:26656,4760b3fc04648522a0bcb2d96a10aadee141ee89@34.89.55.74:26656"
+reason = "Polygon mainnet heimdall-v2 persistent peers."

--- a/.node-updates/mappings.toml
+++ b/.node-updates/mappings.toml
@@ -91,3 +91,9 @@ repo = "bitcoin/bitcoin"
 tag_prefix = ""
 docker_dir = "docker-bitcoin-core"
 package = "bitcoin-core"
+
+[[mapping]]
+repo = "0xPolygon/heimdall-v2"
+tag_prefix = ""
+docker_dir = "docker-heimdall"
+package = "heimdall"

--- a/docker-heimdall/build.toml
+++ b/docker-heimdall/build.toml
@@ -1,7 +1,7 @@
 [package]
 name = "heimdall"
-version = "0.6.0"
-build = "2"
+version = "0.7.1"
+build = "1"
 
 [docker]
 repository = "chainargos/heimdall"

--- a/docker-heimdall/sync-config.rs
+++ b/docker-heimdall/sync-config.rs
@@ -108,7 +108,7 @@ fn main() -> Result<()> {
             "docker", "run",
             "-v", &format!("{heimdall_home}:/heimdall-home:rw"),
             "--entrypoint", "/usr/bin/heimdalld",
-            "-it", &docker_image,
+            &docker_image,
             "init", "chainargos",
             "--home=/heimdall-home",
             "--chain-id", "heimdallv2-137",


### PR DESCRIPTION
https://github.com/0xPolygon/heimdall-v2/releases/tag/v0.7.1

Also includes:
- New mapping entry for `0xPolygon/heimdall-v2` in `.node-updates/mappings.toml`.
- New approved-overrides record at `.node-updates/approved-config-overrides/heimdall.toml` covering `eth_rpc_url`, `bor_rpc_url`, `p2p.seeds`, and `p2p.persistent_peers`. Diffed against upstream `0xpolygon/heimdall-v2:0.7.1` init output; no other drift.
- `docker-heimdall/sync-config.rs`: drop `-it` from the docker invocation so the script works in non-TTY contexts.