### PR TITLE
chore(celo-op-geth): bump to v2.2.3

### DIFF
--- a/docker-celo-op-geth/build.toml
+++ b/docker-celo-op-geth/build.toml
@@ -1,7 +1,7 @@
 [package]
 name = "celo-op-geth"
-version = "2.2.2"
-build = "2"
+version = "2.2.3"
+build = "1"
 
 [docker]
 repository = "chainargos/celo-op-geth"


### PR DESCRIPTION
https://github.com/celo-org/op-geth/releases/tag/celo-v2.2.3