### PR TITLE
chore(bitcoin-cash): bump to v29.0.0

### DIFF
--- a/.node-updates/mappings.toml
+++ b/.node-updates/mappings.toml
@@ -121,3 +121,9 @@ repo = "dogecoin/dogecoin"
 tag_prefix = ""
 docker_dir = "docker-dogecoin-core"
 package = "dogecoin-core"
+
+[[mapping]]
+repo = "bitcoin-cash-node/bitcoin-cash-node"
+tag_prefix = ""
+docker_dir = "docker-bitcoin-cash"
+package = "bitcoin-cash"

--- a/docker-bitcoin-cash/build.toml
+++ b/docker-bitcoin-cash/build.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoin-cash"
-version = "28.0.1"
-build = "2"
+version = "29.0.0"
+build = "1"
 
 [docker]
 repository = "chainargos/bitcoin-cash"


### PR DESCRIPTION
https://github.com/bitcoin-cash-node/bitcoin-cash-node/releases/tag/v29.0.0