### PR TITLE
chore(litecoin-core): bump to v0.21.5.4

### DIFF
--- a/.node-updates/mappings.toml
+++ b/.node-updates/mappings.toml
@@ -103,3 +103,9 @@ repo = "ronin-chain/ronin"
 tag_prefix = ""
 docker_dir = "docker-ronin-geth"
 package = "ronin-geth"
+
+[[mapping]]
+repo = "litecoin-project/litecoin"
+tag_prefix = ""
+docker_dir = "docker-litecoin-core"
+package = "litecoin-core"

--- a/docker-litecoin-core/build.toml
+++ b/docker-litecoin-core/build.toml
@@ -1,7 +1,7 @@
 [package]
 name = "litecoin-core"
-version = "0.21.4"
-build = "2"
+version = "0.21.5.4"
+build = "1"
 
 [docker]
 repository = "chainargos/litecoin-core"


### PR DESCRIPTION
https://github.com/litecoin-project/litecoin/releases/tag/v0.21.5.4