### PR TITLE
chore(bor): bump to v2.7.2

### DIFF
--- a/.node-updates/approved-config-overrides/bor.toml
+++ b/.node-updates/approved-config-overrides/bor.toml
@@ -1,0 +1,101 @@
+# Approved local overrides for sync-config output in docker-bor.
+#
+# Each entry captures a reviewed upstream value and the approved local value
+# that should be restored after running docker-bor/sync-config.rs.
+# If a future sync produces a different upstream value for one of these keys,
+# that change should be shown to the user for review.
+
+package = "bor"
+docker_dir = "docker-bor"
+reviewed_on = "2026-05-04"
+
+[[override]]
+file = "config/config.toml"
+key = "datadir"
+reviewed_upstream_value = "/var/lib/bor/data"
+approved_value = "/data/bor"
+reason = "Container data lives under /data, mounted as the docker volume."
+
+[[override]]
+file = "config/config.toml"
+key = "p2p.port"
+reviewed_upstream_value = 30303
+approved_value = 30305
+reason = "Avoid colliding with the Ethereum geth container's default 30303."
+
+[[override]]
+file = "config/config.toml"
+key = "p2p.maxpendpeers"
+reviewed_upstream_value = "<commented>"
+approved_value = 50
+reason = "Explicitly cap pending peers."
+
+[[override]]
+file = "config/config.toml"
+key = "p2p.bind"
+reviewed_upstream_value = "<commented>"
+approved_value = "0.0.0.0"
+reason = "Bind P2P on all interfaces inside the container."
+
+[[override]]
+file = "config/config.toml"
+key = "p2p.discovery.v4disc"
+reviewed_upstream_value = "<commented>"
+approved_value = true
+reason = "Explicitly enable discv4."
+
+[[override]]
+file = "config/config.toml"
+key = "p2p.discovery.v5disc"
+reviewed_upstream_value = "<commented>"
+approved_value = true
+reason = "Explicitly enable discv5."
+
+[[override]]
+file = "config/config.toml"
+key = "heimdall.url"
+reviewed_upstream_value = "http://localhost:1317"
+approved_value = "http://polygon-heimdall:1317"
+reason = "Point at the container-network Heimdall REST endpoint."
+
+[[override]]
+file = "config/config.toml"
+key = "heimdall.ws-address"
+reviewed_upstream_value = "<absent>"
+approved_value = "ws://polygon-heimdall:26657/websocket"
+reason = "Point at the container-network Heimdall websocket endpoint; not present in upstream template."
+
+[[override]]
+file = "config/config.toml"
+key = "jsonrpc.ipcpath"
+reviewed_upstream_value = "/var/lib/bor/bor.ipc"
+approved_value = "/data/bor/bor.ipc"
+reason = "Match the local datadir override."
+
+[[override]]
+file = "config/config.toml"
+key = "jsonrpc.http.port"
+reviewed_upstream_value = 8545
+approved_value = 8945
+reason = "Avoid colliding with the Ethereum geth container's default 8545."
+
+[[override]]
+file = "config/config.toml"
+key = "jsonrpc.http.host"
+reviewed_upstream_value = "127.0.0.1"
+approved_value = "0.0.0.0"
+reason = "Bind HTTP RPC on all interfaces so the container exposes it to the docker network."
+
+[[override]]
+file = "config/config.toml"
+key = "telemetry.metrics"
+reviewed_upstream_value = true
+approved_value = false
+reason = "We do not export bor metrics; keep telemetry disabled."
+
+[[override]]
+file = "config/config.toml"
+key = "cache.txlookuplimit"
+reviewed_upstream_value = "<commented>"
+approved_value = 0
+reason = "Retain full transaction lookup history (archive-style retention)."

--- a/docker-bor/build.toml
+++ b/docker-bor/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bor"
-version = "2.7.1"
+version = "2.7.2"
 build = "1"
 
 [docker]

--- a/docker-bor/config/config.toml
+++ b/docker-bor/config/config.toml
@@ -14,9 +14,15 @@ syncmode = "full"
 # gcmode = "full"
 # snapshot = true
 # ethstats = ""
+# witnessprotocol = false
 # devfakeauthor = false
 
 # ["eth.requiredblocks"]
+
+# [relay]
+# enable-preconfs = true
+# enable-private-tx = true
+# bp-rpc-endpoints = [ ]
 
 # [log]
     # vmodule = ""
@@ -37,13 +43,14 @@ syncmode = "full"
     # nodekeyhex = ""
     # txarrivalwait = "500ms"
     # txannouncementonly = false
+    # disable-tx-propagation = false
     [p2p.discovery]
         v4disc = true
         v5disc = true
         # bootnodesv4 = []
         # bootnodesv5 = []
-        bootnodes = [ "enode://e4fb013061eba9a2c6fb0a41bbd4149f4808f0fb7e88ec55d7163f19a6f02d64d0ce5ecc81528b769ba552a7068057432d44ab5e9e42842aff5b4709aa2c3f3b@34.89.75.187:30303", "enode://a49da6300403cf9b31e30502eb22c142ba4f77c9dda44990bccce9f2121c3152487ee95ee55c6b92d4cdce77845e40f59fd927da70ea91cf935b23e262236d75@34.142.43.249:30303" ]
-        static-nodes = [ "enode://0e50fdcc2106b0c4e4d9ffbd7798ceda9432e680723dc7b7b4627e384078850c1c4a3e67f17ef2c484201ae6ee7c491cbf5e189b8ffee3948252e9bef59fc54e@35.234.148.172:30303", "enode://e4fb013061eba9a2c6fb0a41bbd4149f4808f0fb7e88ec55d7163f19a6f02d64d0ce5ecc81528b769ba552a7068057432d44ab5e9e42842aff5b4709aa2c3f3b@34.89.75.187:30303", "enode://a49da6300403cf9b31e30502eb22c142ba4f77c9dda44990bccce9f2121c3152487ee95ee55c6b92d4cdce77845e40f59fd927da70ea91cf935b23e262236d75@34.142.43.249:30303", "enode://a0bc4dd2b59370d5a375a7ef9ac06cf531571005ae8b2ead2e9aaeb8205168919b169451fb0ef7061e0d80592e6ed0720f559bd1be1c4efb6e6c4381f1bdb986@35.246.99.203:30303", "enode://f2b0d50e0b843d38ddcab59614f93065e2c82130100032f86ae193eb874505de12fcaf12502dfd88e339b817c0b374fa4b4f7c4d5a4d1aa04f29c503d95e0228@35.197.233.240:30303", "enode://72c3176693f7100dfedc8a37909120fea16971260a5d95ceff49affbc0e23968c35655fee75734736f0b038147645e8ceeee59af68859b3f5bf91fe249be6259@35.246.95.65:30303", "enode://f0e44769385aea31de930d3f4796e3e348962221063bb9f681106d832d13f70e5543d652d30e819812104f1b1ffdd7585977b46bf802ed5a52cf731de8c48dbd@34.105.180.11:30303", "enode://fc7624241515f9d5e599a396362c29de92b13a048ad361c90dd72286aa4cca835ba65e140a46ace70cc4dcb18472a476963750b3b69d958c5f546d48675880a8@34.147.169.102:30303", "enode://198896e373735ba38a0313d073137a413787ece791fbc0d0be0f9f6b9d9dd00ee0841f46519904d666d7f1cdfce5532b093e3a1574b34eb64224f57b9b7fce7b@34.89.55.74:30303" ]
+        # bootnodes = []
+        static-nodes = [ "enode://48e6326841ce106f6b4e229a1be7e98a1d12be57e328b08cb461f6744ae4e78f5ec2340996ce9b40928a1a90137aadea13e25ca34774b52a3600d13a52c5c7bb@34.185.209.56:30303","enode://8ab6905fe76aa9001adb77135250e918db888cac216870c0e95cf26650d83d31d8c2c93d54c3333e0a2196517c41651d174b743ec3e11f44e595f62b77fec7ba@34.185.162.14:30303","enode://02e0b33cf60fb1f88f853c7c04830156151f4acd1c36173cd3fe1f375801fb4f5be5b3a89c98527915d37ed217752933c3faf4c820df740c9dd681294caebcf6@34.179.171.228:30303","enode://079c387b65b09674825462ea63c528ca996af7b03d19b1b2ab6557347434838067db6dd7ae5e0c2e08d5ba164117f3d7faffbf3e890cb91cffbdf45a433ddfce@35.246.166.189:30303","enode://191d06720948ae0119343e5798098f5b1f95a308174c4119d226da91833bc0176009bcc8bf5012e490500562d4d5b5427c307b01f3485b2e8351ac5afd946864@34.142.28.190:30303","enode://30a4651b245e9a0cec674b9ecb5a06ca01553aa727e14a77d0f1ccdb9e48a975f3be631505f417aae438be545ac3b290cd3ed00bef96efd7fb0fb7f916397b3f@34.39.56.114:30303","enode://b950b98b92e118551d79c7280b97ddfcdf3dacb620367ebd45e8382f8e69390df192055386221025ffd3c03912da2aadf668ae6ea7b35f391d82ef87452b3f02@34.147.169.102:30303","enode://92ef18168f6c281a313d0ca76d6122b913a101352b5069af9cea6c8dd0f8b51d669601d59fdf250e972cf9a547d8a10f21ecf5b99ce8511605f328e5f66e845f@34.105.180.11:30303"]
         # trusted-nodes = ["<validator-ip>:<validator-p2p-port>"] # Recommended setting with sentry <> validator architecture
         dns = [ "enrtree://AKUEZKN7PSKVNR65FZDHECMKOJQSGPARGTPPBI7WS2VUL4EGR6XPC@pos.polygon-peers.io" ]
 
@@ -83,6 +90,8 @@ syncmode = "full"
     # txfeecap = 5.0
     # allow-unprotected-txs = false
     # enabledeprecatedpersonal = false
+    # accept-preconf-tx = false
+    # accept-private-tx = false
     [jsonrpc.http]
         enabled = true
         port = 8945


### PR DESCRIPTION
https://github.com/maticnetwork/bor/releases/tag/v2.7.2

Refreshed config/config.toml from upstream template; took the new upstream static-nodes list and accepted new commented-out additions (witnessprotocol, [relay], disable-tx-propagation, accept-preconf-tx, accept-private-tx). Recorded approved local overrides for datadir, p2p.port/maxpendpeers/bind, p2p.discovery.v4disc/v5disc, heimdall.url and ws-address, jsonrpc.ipcpath, jsonrpc.http.port/host, telemetry.metrics, and cache.txlookuplimit.