### PR TITLE
chore(ronin-geth): bump to v1.2.2

### DIFF
--- a/.node-updates/mappings.toml
+++ b/.node-updates/mappings.toml
@@ -97,3 +97,9 @@ repo = "0xPolygon/heimdall-v2"
 tag_prefix = ""
 docker_dir = "docker-heimdall"
 package = "heimdall"
+
+[[mapping]]
+repo = "ronin-chain/ronin"
+tag_prefix = ""
+docker_dir = "docker-ronin-geth"
+package = "ronin-geth"

--- a/docker-ronin-geth/Dockerfile
+++ b/docker-ronin-geth/Dockerfile
@@ -2,7 +2,7 @@ FROM chainargos/debian-blockchain-build:1.1.0@sha256:12b8d0509e772abd9bccde40c49
 
 ARG RONIN_GETH_VERSION
 
-RUN git clone --branch v${RONIN_GETH_VERSION} --single-branch --depth=1 https://github.com/ronin-chain/ronin.git
+RUN git clone --branch ${RONIN_GETH_VERSION} --single-branch --depth=1 https://github.com/ronin-chain/ronin.git
 
 WORKDIR /ronin
 

--- a/docker-ronin-geth/build.toml
+++ b/docker-ronin-geth/build.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ronin-geth"
-version = "1.1.2"
-build = "2"
+version = "1.2.2"
+build = "1"
 
 [docker]
 repository = "chainargos/ronin-geth"


### PR DESCRIPTION
https://github.com/ronin-chain/ronin/releases/tag/1.2.2

Code name: Shoal Star

Upstream dropped the 'v' prefix in their tag scheme starting at v1.2.x (tag is plain '1.2.2'). Updated the Dockerfile to clone the branch using \${RONIN_GETH_VERSION} verbatim instead of v\${...}.