### PR TITLE
ci: use hetzner-sentry runners

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: hetzner-sentry
     concurrency:
       group: build-${{ inputs.package }}
       cancel-in-progress: false

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   renovate:
-    runs-on: ubuntu-24.04
+    runs-on: hetzner-sentry
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## Summary
Route blockchain-nodes workflows from GitHub-hosted Ubuntu runners to the GARM-managed `hetzner-sentry` scale set.

## Testing
- No PR checks are reported for this branch because the changed workflows are reusable, scheduled, main-only, or manually dispatched.
- Did not manually dispatch `build-publish.yml` from the PR branch because that workflow may publish Docker images.

## Migration notes
CI now depends on the Sentry GARM scale set named `hetzner-sentry`.
