### PR TITLE
chore(op-node): bump to v1.18.0

### DIFF
--- a/docker-op-node/build.toml
+++ b/docker-op-node/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "op-node"
-version = "1.17.0"
+version = "1.18.0"
 build = "1"
 
 [docker]


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.18.0