### PR TITLE
chore(op-geth): bump to v1.101702.2

### DIFF
--- a/docker-op-geth/build.toml
+++ b/docker-op-geth/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "op-geth"
-version = "1.101702.1"
+version = "1.101702.2"
 build = "1"
 
 [docker]


### PR DESCRIPTION
https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101702.2