### PR TITLE
chore(cardano-node): bump to v11.0.1

### DIFF
--- a/docker-cardano-node/build.toml
+++ b/docker-cardano-node/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-node"
-version = "10.7.1"
+version = "11.0.1"
 build = "1"
 
 [docker]


### PR DESCRIPTION
https://github.com/IntersectMBO/cardano-node/releases/tag/11.0.1