### PR TITLE
ci: replace hetzner-sentry runner with Velnor, add lane selection

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -12,10 +12,15 @@ on:
         type: boolean
         default: false
         description: "Enable Git LFS for checkout"
+      runner:
+        required: false
+        type: string
+        default: '["self-hosted","velnor-target-mvp"]'
+        description: "runs-on value as JSON (default Velnor self-hosted)"
 
 jobs:
   build:
-    runs-on: hetzner-sentry
+    runs-on: ${{ fromJSON(inputs.runner) }}
     concurrency:
       group: build-${{ inputs.package }}
       cancel-in-progress: false

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      lane:
+        description: |
+          Which runner to build on. These jobs push images (mutating), so they
+          run on a single runner — never both. velnor (default) or github.
+        type: choice
+        default: velnor
+        options: [velnor, github]
 
 permissions:
   contents: read
@@ -15,6 +23,7 @@ jobs:
     secrets: inherit
     with:
       package: debian-blockchain-base
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-debian-blockchain-build:
     needs: docker-debian-blockchain-base
@@ -22,6 +31,7 @@ jobs:
     secrets: inherit
     with:
       package: debian-blockchain-build
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-arbitrum:
     needs: docker-debian-blockchain-build
@@ -29,6 +39,7 @@ jobs:
     secrets: inherit
     with:
       package: arbitrum
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-avalanchego:
     needs: docker-debian-blockchain-build
@@ -36,6 +47,7 @@ jobs:
     secrets: inherit
     with:
       package: avalanchego
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-beacon-kit:
     needs: docker-debian-blockchain-build
@@ -43,6 +55,7 @@ jobs:
     secrets: inherit
     with:
       package: beacon-kit
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-bera-reth:
     needs: docker-debian-blockchain-build
@@ -50,6 +63,7 @@ jobs:
     secrets: inherit
     with:
       package: bera-reth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-bnb-beacon-chain:
     needs: docker-debian-blockchain-build
@@ -57,6 +71,7 @@ jobs:
     secrets: inherit
     with:
       package: bnb-beacon-chain
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-bitcoin-cash:
     needs: docker-debian-blockchain-build
@@ -64,6 +79,7 @@ jobs:
     secrets: inherit
     with:
       package: bitcoin-cash
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-bitcoin-core:
     needs: docker-debian-blockchain-build
@@ -71,6 +87,7 @@ jobs:
     secrets: inherit
     with:
       package: bitcoin-core
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-bor:
     needs: docker-debian-blockchain-build
@@ -78,6 +95,7 @@ jobs:
     secrets: inherit
     with:
       package: bor
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-bsc-geth:
     needs: docker-debian-blockchain-build
@@ -85,6 +103,7 @@ jobs:
     secrets: inherit
     with:
       package: bsc-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-cardano-node:
     needs: docker-debian-blockchain-build
@@ -92,6 +111,7 @@ jobs:
     secrets: inherit
     with:
       package: cardano-node
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-celo-geth:
     needs: docker-debian-blockchain-build
@@ -99,6 +119,7 @@ jobs:
     secrets: inherit
     with:
       package: celo-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-dogecoin-core:
     needs: docker-debian-blockchain-build
@@ -106,6 +127,7 @@ jobs:
     secrets: inherit
     with:
       package: dogecoin-core
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-eigenda-proxy:
     needs: docker-debian-blockchain-build
@@ -113,6 +135,7 @@ jobs:
     secrets: inherit
     with:
       package: eigenda-proxy
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-fetchd:
     needs: docker-debian-blockchain-build
@@ -120,6 +143,7 @@ jobs:
     secrets: inherit
     with:
       package: fetchd
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-fraxtal-op-geth:
     needs: docker-debian-blockchain-build
@@ -127,6 +151,7 @@ jobs:
     secrets: inherit
     with:
       package: fraxtal-op-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-fraxtal-op-node:
     needs: docker-debian-blockchain-build
@@ -134,6 +159,7 @@ jobs:
     secrets: inherit
     with:
       package: fraxtal-op-node
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-geth:
     needs: docker-debian-blockchain-build
@@ -141,6 +167,7 @@ jobs:
     secrets: inherit
     with:
       package: geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-gnosis-geth:
     needs: docker-debian-blockchain-build
@@ -148,6 +175,7 @@ jobs:
     secrets: inherit
     with:
       package: gnosis-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-heco-geth:
     needs: docker-debian-blockchain-build
@@ -155,6 +183,7 @@ jobs:
     secrets: inherit
     with:
       package: heco-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-heimdall:
     needs: docker-debian-blockchain-build
@@ -163,6 +192,7 @@ jobs:
     with:
       package: heimdall
       enable-lfs: true
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-kcc-geth:
     needs: docker-debian-blockchain-build
@@ -170,6 +200,7 @@ jobs:
     secrets: inherit
     with:
       package: kcc-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-lighthouse:
     needs: docker-debian-blockchain-build
@@ -177,6 +208,7 @@ jobs:
     secrets: inherit
     with:
       package: lighthouse
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-litecoin-core:
     needs: docker-debian-blockchain-build
@@ -184,6 +216,7 @@ jobs:
     secrets: inherit
     with:
       package: litecoin-core
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-octez:
     needs: docker-debian-blockchain-build
@@ -191,6 +224,7 @@ jobs:
     secrets: inherit
     with:
       package: octez
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-omnicore:
     needs: docker-debian-blockchain-build
@@ -198,6 +232,7 @@ jobs:
     secrets: inherit
     with:
       package: omnicore
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-celo-op-geth:
     needs: docker-debian-blockchain-build
@@ -205,6 +240,7 @@ jobs:
     secrets: inherit
     with:
       package: celo-op-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-celo-op-node:
     needs: docker-debian-blockchain-build
@@ -212,6 +248,7 @@ jobs:
     secrets: inherit
     with:
       package: celo-op-node
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-op-geth:
     needs: docker-debian-blockchain-build
@@ -219,6 +256,7 @@ jobs:
     secrets: inherit
     with:
       package: op-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-op-node:
     needs: docker-debian-blockchain-build
@@ -226,6 +264,7 @@ jobs:
     secrets: inherit
     with:
       package: op-node
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-ronin-geth:
     needs: docker-debian-blockchain-build
@@ -233,6 +272,7 @@ jobs:
     secrets: inherit
     with:
       package: ronin-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-scroll-geth:
     needs: docker-debian-blockchain-build
@@ -240,6 +280,7 @@ jobs:
     secrets: inherit
     with:
       package: scroll-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-sonic-geth:
     needs: docker-debian-blockchain-build
@@ -247,6 +288,7 @@ jobs:
     secrets: inherit
     with:
       package: sonic-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-tron-java:
     needs: docker-debian-blockchain-build
@@ -254,6 +296,7 @@ jobs:
     secrets: inherit
     with:
       package: tron-java
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}
 
   docker-wbt-geth:
     needs: docker-debian-blockchain-build
@@ -261,3 +304,4 @@ jobs:
     secrets: inherit
     with:
       package: wbt-geth
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && '"ubuntu-latest"' || '["self-hosted","velnor-target-mvp"]' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,10 +8,22 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      lane:
+        description: |
+          Which runner to run on. Renovate mutates state (opens PRs), so it runs
+          on a single runner — never both. velnor (default) or github.
+        type: choice
+        default: velnor
+        options: [velnor, github]
+
+concurrency:
+  group: renovate
+  cancel-in-progress: true
 
 jobs:
   renovate:
-    runs-on: hetzner-sentry
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && fromJSON('"ubuntu-latest"') || fromJSON('["self-hosted","velnor-target-mvp"]') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 


### PR DESCRIPTION
## Summary

- `build-image.yml` — add `runner` input (default: Velnor JSON label `["self-hosted","velnor-target-mvp"]`); change hardcoded `runs-on: hetzner-sentry` to `fromJSON(inputs.runner)`
- `build-publish.yml` — add `lane` dispatch input (`velnor`/`github`, default `velnor`); pass runner expression to every `build-image.yml` call
- `renovate.yml` — add `lane` dispatch input; default to Velnor runner; add `concurrency` group to prevent duplicate Renovate runs

All three workflows previously used `runs-on: hetzner-sentry` (the old GARM runner label). GARM has been removed from the sentry server; those jobs would hang waiting for a runner that no longer exists.

Pattern matches `ChainArgos/java-monorepo` kestra and Renovate workflows: mutating jobs use a `lane` input (single runner, no `both` option) with Velnor as the default.

## Test plan

- [ ] Dispatch `Build And Publish All` with `lane=velnor` — jobs should be picked up by the Velnor runner on sentry
- [ ] Dispatch `Build And Publish All` with `lane=github` — jobs should run on `ubuntu-latest`
- [ ] Dispatch `Renovate` manually — runs on Velnor by default
- [ ] Confirm no jobs show "waiting for a runner" on the `hetzner-sentry` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)