### PR TITLE
ci: replace dtolnay/rust-toolchain + cargo-install with mise-action

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -30,22 +30,24 @@ jobs:
         with:
           lfs: ${{ inputs.enable-lfs }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
-      - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+      # mise installs rust-script via cargo and manages PATH correctly in both
+      # GitHub-hosted and Velnor self-hosted containers. Replaces the previous
+      # dtolnay/rust-toolchain + baptiste0928/cargo-install combination which
+      # failed on Velnor because GITHUB_PATH updates did not propagate between steps.
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          crate: rust-script
-          locked: true
+          install_args: "cargo:rust-script"
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Cache rust-script
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          shared-key: "rust-build-cache"
-          cache-on-failure: true
+          path: ~/.cache/rust-script
+          key: rust-script-${{ runner.os }}-${{ hashFiles('**/*.rs', '**/build.toml') }}
+          restore-keys: |
+            rust-script-${{ runner.os }}-
 
       - name: Check if image exists
         id: check-image


### PR DESCRIPTION
## Summary

`baptiste0928/cargo-install` fails on Velnor self-hosted containers: `Unable to locate executable file: cargo`. Root cause: `dtolnay/rust-toolchain@stable` writes to `$GITHUB_PATH` to expose cargo, but in Velnor's Docker container environment that file update is not re-read between steps. GitHub-hosted runners are unaffected.

Fix: replace the two-step `dtolnay/rust-toolchain` + `cargo-install` with `jdx/mise-action` (same approach as `java-monorepo`'s `kestra-build-image.yml`). mise manages its own PATH correctly in all runner environments. Add `actions/cache` for the rust-script compilation cache.

## Test plan

- [ ] Merge and trigger `Build And Publish All` with `lane=velnor` — `docker-debian-blockchain-base` should pass `mise` step without "cargo not found"
- [ ] Also works with `lane=github` (mise-action is compatible with GitHub-hosted runners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)