### PR TITLE
fix(ci): add mise.toml to activate rust-script shim

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"cargo:rust-script" = "latest"


### PR DESCRIPTION
## Summary

- Adds `mise.toml` with `"cargo:rust-script" = "latest"` to fix the regression introduced by #580

## Root cause

`jdx/mise-action` installs `cargo:rust-script` but mise shims require a version configured in `mise.toml`. Without it, any step that invokes `rust-script` via the mise shim (e.g. `./docker-build.rs` with shebang `#!/usr/bin/env rust-script`) fails:

```
mise ERROR No version is set for shim: rust-script
```

This affects both GitHub-hosted and Velnor runners identically.

## Test plan

- [ ] `docker-debian-blockchain-base / build` passes on Velnor lane
- [ ] `docker-debian-blockchain-base / build` passes on GitHub lane

Co-authored-by: Claude <noreply@anthropic.com>