### PR TITLE
fix(ci): update mise task args syntax and fix buildx for Velnor

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Initialize Docker Buildx
         if: steps.check-image.outputs.exists == 'false'
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        run: docker buildx create --driver docker-container --use
 
       - name: Build Docker image
         if: steps.check-image.outputs.exists == 'false'

--- a/mise.toml
+++ b/mise.toml
@@ -3,31 +3,38 @@
 
 [tasks.build]
 description = "Build a Docker image"
-run = "./docker-build.rs {{arg(name='package')}}"
+usage = "build <package>"
+run = "./docker-build.rs $1"
 
 [tasks."build-dry"]
 description = "Build a Docker image (dry run)"
-run = "./docker-build.rs {{arg(name='package')}} --dry-run"
+usage = "build-dry <package>"
+run = "./docker-build.rs $1 --dry-run"
 
 [tasks.exists]
 description = "Check if Docker image exists on Docker Hub"
-run = "./docker-exists.rs {{arg(name='package')}}"
+usage = "exists <package>"
+run = "./docker-exists.rs $1"
 
 [tasks."exists-verbose"]
 description = "Check if Docker image exists (verbose)"
-run = "./docker-exists.rs {{arg(name='package')}} --verbose"
+usage = "exists-verbose <package>"
+run = "./docker-exists.rs $1 --verbose"
 
 [tasks."exists-platform"]
 description = "Check if platform-specific Docker image exists"
-run = "./docker-exists.rs {{arg(name='package')}} --platform {{arg(name='platform')}}"
+usage = "exists-platform <package> <platform>"
+run = "./docker-exists.rs $1 --platform $2"
 
 [tasks.restart]
 description = "Restart a container with log following"
-run = "./containerctl.rs restart {{arg(name='container')}} -f"
+usage = "restart <container>"
+run = "./containerctl.rs restart $1 -f"
 
 [tasks.stop]
 description = "Stop a container"
-run = "./containerctl.rs stop {{arg(name='container')}}"
+usage = "stop <container>"
+run = "./containerctl.rs stop $1"
 
 [tasks."build-all"]
 description = "Build all Docker images in sequence"


### PR DESCRIPTION
## Summary

- Replace deprecated `{{arg(name='...')}}` Tera template syntax in `mise.toml` with positional `$1`/`$2` args and `usage` fields (mise deprecation warning: removed in mise 2027.5.0)
- Replace `docker/setup-buildx-action` native action with inline `docker buildx create --driver docker-container --use` run step — the native action creates the builder on the host context (`~/.docker/buildx/`), but `run:` steps execute inside the job container which has a fresh empty Docker config, causing `ERROR: no builder "velnor-builder" found`

## Test plan

- [ ] Trigger a build job and verify no `mise WARN deprecated [tera_template_task_args]` warning
- [ ] Verify buildx builder created successfully and `mise run build <package>` completes without `no builder found` error