### PR TITLE
fix(ci): fix mise usage field format (must start with 'run')

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,37 +3,37 @@
 
 [tasks.build]
 description = "Build a Docker image"
-usage = "build <package>"
+usage = "run <package>"
 run = "./docker-build.rs $1"
 
 [tasks."build-dry"]
 description = "Build a Docker image (dry run)"
-usage = "build-dry <package>"
+usage = "run <package>"
 run = "./docker-build.rs $1 --dry-run"
 
 [tasks.exists]
 description = "Check if Docker image exists on Docker Hub"
-usage = "exists <package>"
+usage = "run <package>"
 run = "./docker-exists.rs $1"
 
 [tasks."exists-verbose"]
 description = "Check if Docker image exists (verbose)"
-usage = "exists-verbose <package>"
+usage = "run <package>"
 run = "./docker-exists.rs $1 --verbose"
 
 [tasks."exists-platform"]
 description = "Check if platform-specific Docker image exists"
-usage = "exists-platform <package> <platform>"
+usage = "run <package> <platform>"
 run = "./docker-exists.rs $1 --platform $2"
 
 [tasks.restart]
 description = "Restart a container with log following"
-usage = "restart <container>"
+usage = "run <container>"
 run = "./containerctl.rs restart $1 -f"
 
 [tasks.stop]
 description = "Stop a container"
-usage = "stop <container>"
+usage = "run <container>"
 run = "./containerctl.rs stop $1"
 
 [tasks."build-all"]


### PR DESCRIPTION
## Summary

- Fix `usage` field in all parameterized mise tasks — must start with `run` keyword per mise task arguments spec (e.g. `"run <package>"` not `"build <package>"`)
- Previous format → `[build] ERROR Invalid usage config` / `[exists] ERROR task failed` on every job

## Test plan

- [ ] Trigger a build job and verify `mise run exists <package>` and `mise run build <package>` succeed without `Invalid usage config` error