### PR TITLE
fix(ci): add Docker Hub credentials to Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,3 +35,4 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: false
           LOG_LEVEL: debug
+          RENOVATE_HOST_RULES: '[{"matchHost":"index.docker.io","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'


### PR DESCRIPTION
## Summary

- Renovate hitting Docker Hub unauthenticated → 429 rate limit on `chainargos/debian-blockchain-base` manifest fetches → `external-host-error` → workflow exit non-zero
- Fix: pass `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` via `RENOVATE_HOST_RULES` env var so all `index.docker.io` requests are authenticated

## Test plan

- [ ] Trigger Renovate run and verify no Docker Hub 429/401 errors in log