### PR TITLE
fix(ci): remove usage field from mise tasks (causes Invalid usage config)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,37 +3,30 @@
 
 [tasks.build]
 description = "Build a Docker image"
-usage = "run <package>"
 run = "./docker-build.rs $1"
 
 [tasks."build-dry"]
 description = "Build a Docker image (dry run)"
-usage = "run <package>"
 run = "./docker-build.rs $1 --dry-run"
 
 [tasks.exists]
 description = "Check if Docker image exists on Docker Hub"
-usage = "run <package>"
 run = "./docker-exists.rs $1"
 
 [tasks."exists-verbose"]
 description = "Check if Docker image exists (verbose)"
-usage = "run <package>"
 run = "./docker-exists.rs $1 --verbose"
 
 [tasks."exists-platform"]
 description = "Check if platform-specific Docker image exists"
-usage = "run <package> <platform>"
 run = "./docker-exists.rs $1 --platform $2"
 
 [tasks.restart]
 description = "Restart a container with log following"
-usage = "run <container>"
 run = "./containerctl.rs restart $1 -f"
 
 [tasks.stop]
 description = "Stop a container"
-usage = "run <container>"
 run = "./containerctl.rs stop $1"
 
 [tasks."build-all"]


### PR DESCRIPTION
## Summary

The mise `usage` field introduced in PR #584 is broken in mise 2026.3.10 (the version on the Velnor host). Any value in the `usage` field produces `Invalid usage config` and fails the task, regardless of format.

Tested directly on sentry:
- `usage = "run <package>"` → `Invalid usage config`
- `usage = "<package>"` → `Invalid usage config`
- No `usage` field + `$1` positional arg → works correctly

Positional `$1`/`$2` args in `run` scripts work without any `usage` declarations. Removing the `usage` fields entirely.

## Test plan

- [ ] `mise run exists geth` returns `true`/`false` without `Invalid usage config` error
- [ ] `mise run build geth` executes `./docker-build.rs geth`