### PR TITLE
chore(mise): use named arg syntax with usage field for task arguments

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,31 +3,41 @@
 
 [tasks.build]
 description = "Build a Docker image"
-run = "./docker-build.rs $1"
+usage = 'arg "<package>" help="Package name to build"'
+run = "./docker-build.rs ${usage_package:?}"
 
 [tasks."build-dry"]
 description = "Build a Docker image (dry run)"
-run = "./docker-build.rs $1 --dry-run"
+usage = 'arg "<package>" help="Package name to build"'
+run = "./docker-build.rs ${usage_package:?} --dry-run"
 
 [tasks.exists]
 description = "Check if Docker image exists on Docker Hub"
-run = "./docker-exists.rs $1"
+usage = 'arg "<package>" help="Package name"'
+run = "./docker-exists.rs ${usage_package:?}"
 
 [tasks."exists-verbose"]
 description = "Check if Docker image exists (verbose)"
-run = "./docker-exists.rs $1 --verbose"
+usage = 'arg "<package>" help="Package name"'
+run = "./docker-exists.rs ${usage_package:?} --verbose"
 
 [tasks."exists-platform"]
 description = "Check if platform-specific Docker image exists"
-run = "./docker-exists.rs $1 --platform $2"
+usage = '''
+arg "<package>" help="Package name"
+arg "<platform>" help="Platform (e.g. amd64, arm64)"
+'''
+run = "./docker-exists.rs ${usage_package:?} --platform ${usage_platform:?}"
 
 [tasks.restart]
 description = "Restart a container with log following"
-run = "./containerctl.rs restart $1 -f"
+usage = 'arg "<container>" help="Container name"'
+run = "./containerctl.rs restart ${usage_container:?} -f"
 
 [tasks.stop]
 description = "Stop a container"
-run = "./containerctl.rs stop $1"
+usage = 'arg "<container>" help="Container name"'
+run = "./containerctl.rs stop ${usage_container:?}"
 
 [tasks."build-all"]
 description = "Build all Docker images in sequence"

--- a/mise.toml
+++ b/mise.toml
@@ -3,37 +3,30 @@
 
 [tasks.build]
 description = "Build a Docker image"
-usage = "run <package>"
 run = "./docker-build.rs $1"
 
 [tasks."build-dry"]
 description = "Build a Docker image (dry run)"
-usage = "run <package>"
 run = "./docker-build.rs $1 --dry-run"
 
 [tasks.exists]
 description = "Check if Docker image exists on Docker Hub"
-usage = "run <package>"
 run = "./docker-exists.rs $1"
 
 [tasks."exists-verbose"]
 description = "Check if Docker image exists (verbose)"
-usage = "run <package>"
 run = "./docker-exists.rs $1 --verbose"
 
 [tasks."exists-platform"]
 description = "Check if platform-specific Docker image exists"
-usage = "run <package> <platform>"
 run = "./docker-exists.rs $1 --platform $2"
 
 [tasks.restart]
 description = "Restart a container with log following"
-usage = "run <container>"
 run = "./containerctl.rs restart $1 -f"
 
 [tasks.stop]
 description = "Stop a container"
-usage = "run <container>"
 run = "./containerctl.rs stop $1"
 
 [tasks."build-all"]


### PR DESCRIPTION
## Summary

- Replace positional `$1`/`$2` in all mise task `run` scripts with named `${usage_name:?}` env vars
- Add `usage = 'arg "<name>"'` (or multiline for two-arg tasks) to each parameterized task
- Tested against mise 2026.6.0 (container image) — `build geth` and `exists-platform geth amd64` both work correctly

## Test plan

- [ ] CI `build-image` workflow passes with named args
- [ ] Missing arg produces clear error (`usage_package: parameter null or not set`) instead of silent empty `$1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)