### PR TITLE
chore(arbitrum): update to v3.10.2-db30ef0

### DIFF
--- a/docker-arbitrum/build.toml
+++ b/docker-arbitrum/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbitrum"
-version = "3.10.1"
+version = "3.10.2"
 build = "1"
 
 [docker]
@@ -8,4 +8,4 @@ repository = "chainargos/arbitrum"
 platforms = ["amd64", "arm64"]
 
 [vars]
-git_commit = "6b0af88"
+git_commit = "db30ef0"


### PR DESCRIPTION
## Summary

- Updates `docker-arbitrum` from `v3.10.1-6b0af88` to `v3.10.2-db30ef0`
- The old tag `offchainlabs/nitro-node:v3.10.1-6b0af88` does not exist on Docker Hub, causing all builds to fail with `not found`
- `v3.10.2-db30ef0` is the latest available upstream release

## Test plan
- [ ] Trigger `Build And Publish All` on velnor lane — `docker-arbitrum / build` should pass
- [ ] Trigger `Build And Publish All` on github lane — `docker-arbitrum / build` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)