### PR TITLE
ci: add QEMU setup for multi-arch Docker builds

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -64,6 +64,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        if: steps.check-image.outputs.exists == 'false'
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
       - name: Initialize Docker Buildx
         if: steps.check-image.outputs.exists == 'false'
         run: docker buildx create --driver docker-container --use


### PR DESCRIPTION
## Summary

- Adds `docker/setup-qemu-action@v4.1.0` step before Docker Buildx initialization
- Fixes `docker-arbitrum / build` failure: the Dockerfile runs `RUN ls` and `RUN chown` in the `linux/arm64` context (via offchainlabs/nitro-node base image), which requires QEMU on amd64 runners
- QEMU is only installed when a build is actually needed (gated on `steps.check-image.outputs.exists == 'false'`)

## Root cause

`docker-arbitrum` copies files from `offchainlabs/nitro-node` (multi-arch) using a multi-stage build. The build stage contains `RUN ls` which executes in the arm64 container context. On amd64 runners without QEMU binfmt support, this fails immediately with `exec format error`.

Other images that have `platforms = ["amd64", "arm64"]` were not affected because their images already existed on Docker Hub (check-image step skips them). Arbitrum was affected because its version tag (`v3.10.1-6b0af88`) did not exist, forcing a fresh build that exposed the missing QEMU support.

## Test plan
- [ ] `docker-arbitrum / build` passes on velnor lane
- [ ] `docker-arbitrum / build` passes on GitHub lane
- [ ] All other jobs still pass (QEMU installation is fast; image-exists check is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)