### PR TITLE
ci: replace setup-qemu-action with direct run step

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Set up QEMU
         if: steps.check-image.outputs.exists == 'false'
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        run: docker run --rm --privileged tonistiigi/binfmt:latest --install all
 
       - name: Initialize Docker Buildx
         if: steps.check-image.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

- Replaces `docker/setup-qemu-action@v4.1.0` with an equivalent direct shell command
- The action uses `node24` which is not available in the velnor job container, causing the step to fail
- The equivalent command `docker run --rm --privileged tonistiigi/binfmt:latest --install all` does exactly what the action does internally

## Context

Previous PR #589 added QEMU support but used the GitHub Action which requires Node.js 24. The velnor job container has Node.js 20 (via mise), so the action step fails immediately. This PR replaces it with the direct Docker command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)