### PR TITLE
fix(ci): replace docker/login-action with shell docker login

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -59,10 +59,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: steps.check-image.outputs.exists == 'false'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
       - name: Set up QEMU
         if: steps.check-image.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

- Replace `docker/login-action` (JS action) with `run: echo "$DOCKERHUB_TOKEN" | docker login --password-stdin` (shell step)

## Root cause

Velnor runs JavaScript actions in ephemeral node sidecar containers with their own filesystem and HOME (the `mise-action` comment in this workflow already documents this: "GITHUB_PATH updates don't propagate between ephemeral node sidecar containers"). `docker/login-action` writes Docker Hub credentials to the sidecar's `~/.docker/config.json`, which is **not visible** to subsequent `run:` steps executing in the main job container.

Result: when `docker buildx build` runs (via `mise run build`), the main container's `~/.docker/config.json` has no Docker Hub auth. The Docker client passes no credentials to buildkitd, and buildkitd hits Docker Hub's unauthenticated pull rate limit (HTTP 429) when pulling `chainargos/debian-blockchain-base:1.1.0` in the second Dockerfile stage.

```
toomanyrequests: You have reached your unauthenticated pull rate limit.
```

## Fix

`run:` steps execute in the main job container. Replacing the JS action with a shell `docker login` call writes credentials to the correct `~/.docker/config.json`, which `docker buildx build` then reads and forwards to buildkitd via gRPC SolveRequest — allowing authenticated pulls of all base images.

Co-authored-by: Claude <noreply@anthropic.com>