### PR TITLE
fix(ci): split build concurrency by runner

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ${{ fromJSON(inputs.runner) }}
     concurrency:
-      group: build-${{ inputs.package }}
+      group: build-${{ inputs.package }}-${{ inputs.runner }}
       cancel-in-progress: false
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- include the runner input in reusable Docker build concurrency groups
- let GitHub-hosted and Velnor lanes for the same package queue independently

## Testing
- not run; workflow-only concurrency change