### PR TITLE
ci: standardize renovate lane name

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   renovate:
+    name: Renovate (${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && 'GitHub' || 'Velnor' }})
     runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane == 'github') && fromJSON('"ubuntu-latest"') || fromJSON('["self-hosted","velnor-target-mvp"]') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
## Summary
Adds the selected runner lane to the blockchain Renovate job title so single-runner jobs follow the same `GitHub` / `Velnor` display convention already used by the build matrix.

## Testing
- Parsed all .github/workflows/*.yml with Ruby Psych

## Migration notes
None.