### PR TITLE
ci: timeout Docker Hub existence checks

### DIFF
--- a/docker-exists.rs
+++ b/docker-exists.rs
@@ -13,6 +13,7 @@ use clap::builder::styling::{AnsiColor, Effects, Styles};
 use clap::Parser;
 use serde::Deserialize;
 use std::env;
+use std::time::Duration;
 
 const HELP_STYLES: Styles = Styles::styled()
     .header(AnsiColor::Blue.on_default().effects(Effects::BOLD))
@@ -146,6 +147,7 @@ fn check_image_exists(repository: &str, tag: &str, verbose: bool) -> Result<bool
 
     let client = reqwest::blocking::Client::builder()
         .user_agent("docker-exists/1.0")
+        .timeout(Duration::from_secs(20))
         .build()
         .context("Failed to create HTTP client")?;
 


### PR DESCRIPTION
Adds a bounded reqwest timeout to the Rust docker-exists script so CI jobs cannot hang indefinitely while checking Docker Hub tags.\n\nValidation:\n- mise run exists debian-blockchain-base returned true locally\n- Previous both-runner build-publish run 27100305339 completed successfully before this timeout-only hardening change