### PR TITLE
fix(ci): cache rust-script via ~ paths; pin rust-script 0.36.0

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Cache rust-script
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          path: ${{ matrix.config.lane == 'GitHub' && '~/.cache/rust-script' || '/root/.cache/rust-script' }}
+          path: ~/.cache/rust-script
           key: rust-script-${{ matrix.config.lane }}-${{ runner.os }}-${{ hashFiles('**/*.rs') }}
           restore-keys: |
             rust-script-${{ matrix.config.lane }}-${{ runner.os }}-
@@ -180,7 +180,7 @@ jobs:
       - name: Cache rust-script
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          path: ${{ matrix.config.lane == 'GitHub' && '~/.cache/rust-script' || '/root/.cache/rust-script' }}
+          path: ~/.cache/rust-script
           key: rust-script-${{ matrix.config.lane }}-${{ runner.os }}-${{ hashFiles('**/*.rs') }}
           restore-keys: |
             rust-script-${{ matrix.config.lane }}-${{ runner.os }}-
@@ -242,7 +242,7 @@ jobs:
       - name: Cache rust-script
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          path: ${{ matrix.config.lane == 'GitHub' && '~/.cache/rust-script' || '/root/.cache/rust-script' }}
+          path: ~/.cache/rust-script
           key: rust-script-${{ matrix.config.lane }}-${{ runner.os }}-${{ hashFiles('**/*.rs') }}
           restore-keys: |
             rust-script-${{ matrix.config.lane }}-${{ runner.os }}-

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"cargo:rust-script" = "latest"
+"cargo:rust-script" = "0.36.0"
 
 [tasks.build]
 description = "Build a Docker image"


### PR DESCRIPTION
## Why

The `/root/.cache/rust-script` lane split in `build-publish.yml` worked around the Velnor runner exporting `HOME=/root` into run steps. Velnor 0.1.18 now gives steps the truthful bind-mounted `HOME=/github/home` and no longer resolves unmapped absolute container paths to the daemon host — so the `/root` path caches **nothing** on the Velnor lane.

## What

- **`.github/workflows/build-publish.yml`**: replace the lane-conditional cache path
  `${{ matrix.config.lane == 'GitHub' && '~/.cache/rust-script' || '/root/.cache/rust-script' }}`
  with plain `~/.cache/rust-script` in all 3 jobs (`base`, `build`, `packages`). `~` now resolves correctly on both lanes. Cache keys unchanged.
- **`mise.toml`**: pin `cargo:rust-script` to `0.36.0` (estate-wide pin) so a cache miss never compiles `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
