### PR TITLE
feat(skills): multi-agent discovery + de-duplicate agent config

### DIFF
--- a/.agents/skills/update-node-version
+++ b/.agents/skills/update-node-version
@@ -1,0 +1,1 @@
+../../.claude/skills/update-node-version

--- a/.claude/skills/update-node-version/README.md
+++ b/.claude/skills/update-node-version/README.md
@@ -1,6 +1,8 @@
 # update-node-version
 
-A Claude Code discovery entry point for the node-version-update workflow. The workflow itself lives at [`NODE_UPDATES.md`](../../../NODE_UPDATES.md) in the repo root so Codex, Amp, and any other agent that reads `AGENTS.md` can follow the same procedure without duplicating instructions.
+A Claude Code discovery entry point for the node-version-update workflow. The workflow itself lives at [`NODE_UPDATES.md`](../../../NODE_UPDATES.md) in the repo root so any agent that reads `AGENTS.md` (Codex, Amp, Grok, etc.) can follow the same procedure without duplicating instructions.
+
+OpenCode discovers this skill natively because it reads `.claude/skills/*/SKILL.md` as a Claude-compatible path, so no separate shim is required for it.
 
 ## Usage
 
@@ -8,7 +10,7 @@ Paste a GitHub release URL in chat, e.g.:
 
 > update bsc to https://github.com/bnb-chain/bsc/releases/tag/v1.7.3
 
-Claude picks up this skill via its frontmatter description and jumps to `NODE_UPDATES.md`. Codex and Amp users should read `NODE_UPDATES.md` directly (it is linked from `AGENTS.md`).
+Claude and OpenCode pick up this skill via its frontmatter description (OpenCode reads the `.claude/skills/` path directly) and jump to `NODE_UPDATES.md`. Codex, Amp, and Grok users should read `NODE_UPDATES.md` directly (it is linked from `AGENTS.md`).
 
 ## Config correctness
 
@@ -39,7 +41,7 @@ Then re-run the workflow. Commit the `mappings.toml` change as a normal `chore` 
 
 ## Files
 
-- `SKILL.md` — Claude Code discovery shim that points at `NODE_UPDATES.md`.
+- `SKILL.md` — discovery shim that points at `NODE_UPDATES.md`.
 - `README.md` — this file.
 
-The workflow and mapping data live outside this directory so they are agent-neutral.
+The real skill directory is `.claude/skills/update-node-version/`. It is symlinked at `.agents/skills/update-node-version` so Codex (which ignores `.claude/skills/`) discovers the same single file — see [`SKILLS.md`](../../../SKILLS.md). The workflow and mapping data live outside this directory so they are agent-neutral.

--- a/.claude/skills/update-node-version/SKILL.md
+++ b/.claude/skills/update-node-version/SKILL.md
@@ -5,14 +5,12 @@ description: Use when the user provides a GitHub release URL for a blockchain no
 
 # update-node-version
 
-This skill is a thin wrapper. The full workflow lives in the repo root at [`NODE_UPDATES.md`](../../../NODE_UPDATES.md) so Codex, Amp, and any other agent that reads `AGENTS.md` can follow the same procedure.
+Bump a packaged blockchain node to a new upstream release. The full workflow — URL parsing, mapping lookup, `build.toml` edit, sync-config reconciliation, human gate, branch/commit/PR — lives in [`NODE_UPDATES.md`](../../../NODE_UPDATES.md).
 
-**Read `NODE_UPDATES.md` and follow its workflow exactly.** The mapping table is at `.node-updates/mappings.toml`.
+**Read `NODE_UPDATES.md` and follow its workflow exactly.** The human-gate and no-auto-merge rules there are mandatory.
 
-Important: for packages with `sync-config.rs`, consult `.node-updates/approved-config-overrides/<package>.toml` before deciding whether a config diff is already approved or needs user review. Do not treat unchecked local values as automatically approved.
+## Gotchas
 
-Use the commit trailer that matches the current agent, as documented in [`COMMITS.md`](../../../COMMITS.md) and [`AGENTS.md`](../../../AGENTS.md):
-
-```text
-Co-authored-by: <current-agent> <agent-email>
-```
+- The release URL must match an entry in `.node-updates/mappings.toml`. If it does not, the workflow directs you to add one — do not guess the `docker_dir` or `package`.
+- For packages with `sync-config.rs`, consult `.node-updates/approved-config-overrides/<package>.toml` before treating a config diff as already approved. Do not accept unchecked local values as automatically approved.
+- `sync-config.rs` output is upstream reference material, not repo content to be applied blindly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,38 +15,6 @@ This repository uses `main` as its primary branch. This file is the canonical ho
 
 If you are uncertain whether authorization applies to the PR in front of you, ask. The cost of pausing is ~30 seconds; the cost of merging something the operator wasn't ready for is much higher.
 
-## Commit Attribution (agent-only)
-
-Every commit created by an AI agent in this repository must include **exactly one** `Co-authored-by` trailer identifying the agent that made the commit. The trailer identifies the **agent tool**, not the underlying model — **never stack multiple agent trailers on one commit** (for example, an Amp-generated commit must not also carry `Co-authored-by: Claude` or `Co-authored-by: Codex` just because Amp used one of those vendors' models under the hood).
-
-Until the listed agents emit their trailers automatically, the trailer must be added by hand when creating or amending the commit.
-
-**Trailers by agent:**
-
-- **Claude** (Claude Code CLI, or any Claude-API coding agent used directly):
-
-  ```text
-  Co-authored-by: Claude <noreply@anthropic.com>
-  ```
-
-- **Codex** (OpenAI Codex CLI):
-
-  ```text
-  Co-authored-by: Codex <codex@openai.com>
-  ```
-
-- **Amp** (Sourcegraph Amp, regardless of underlying model):
-
-  ```text
-  Co-authored-by: Amp <amp@ampcode.com>
-  ```
-
-Amp may additionally emit an `Amp-Thread-ID:` metadata trailer; that is acceptable alongside the single `Co-authored-by: Amp` trailer because the thread ID identifies the conversation, not a second agent.
-
-If you are uncertain which agent is creating the commit, ask — the trailer is how the operator tracks which agent produced which change, and wrong attribution is worse than no attribution.
-
-See [COMMITS.md](COMMITS.md) for the repo's commit-message format.
-
 ## Release code names in node-update PRs (agent-only)
 
 Some upstream releases carry a human-readable code name (e.g., Ronin 1.2.2 is **"Shoal Star"**). When opening a node-update PR, include the code name in the PR body if the upstream release has one.
@@ -67,6 +35,7 @@ Rules in the files below apply to everyone working in the repo — human and age
 
 - [RULES.md](RULES.md) — documentation-location convention (no project rules in tool-specific files).
 - [BRANCHING.md](BRANCHING.md) — branch naming, feature-branch policy, what never to commit to `main`.
-- [COMMITS.md](COMMITS.md) — Conventional Commits format and agent-attribution trailer.
+- [COMMITS.md](COMMITS.md) — Conventional Commits format.
 - [BUILD_SYSTEM.md](BUILD_SYSTEM.md) — Rust-based Docker build system: `build.toml` schema, `mise run build <pkg>`, tag formats.
 - [NODE_UPDATES.md](NODE_UPDATES.md) — workflow for bumping a blockchain node from a GitHub release URL; mapping table at `.node-updates/mappings.toml`.
+- [SKILLS.md](SKILLS.md) — agent-neutral skill authoring/placement: real skill in `.claude/skills/`, symlink at `.agents/skills/` for Codex; single source of truth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+AGENTS.md

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,6 +1,6 @@
 # Commits
 
-This file covers commit message format and agent attribution. Both apply to every commit in this repository.
+This file covers commit message format. It applies to every commit in this repository.
 
 ## Commit Messages
 
@@ -29,34 +29,6 @@ Scope is optional but encouraged when it clarifies the change area, e.g., `chore
 Breaking changes use `!` after the type/scope (`feat!:` or `feat(api)!:`) and include a `BREAKING CHANGE:` footer in the body.
 
 PRs are squash-merged, so the PR title becomes the commit subject and must also follow this convention.
-
-## Agent Attribution
-
-Every commit created by an AI agent MUST include exactly one `Co-authored-by` trailer identifying the agent. The trailer identifies the **agent tool**, not the underlying model. Never stack multiple agent trailers on one commit.
-
-Trailers per agent:
-
-- **Claude** (Claude Code CLI, or any Claude-API coding agent used directly):
-
-  ```text
-  Co-authored-by: Claude <noreply@anthropic.com>
-  ```
-
-- **Codex** (OpenAI Codex CLI):
-
-  ```text
-  Co-authored-by: Codex <codex@openai.com>
-  ```
-
-- **Amp** (Sourcegraph Amp, regardless of underlying model):
-
-  ```text
-  Co-authored-by: Amp <amp@ampcode.com>
-  ```
-
-Amp may additionally emit an `Amp-Thread-ID:` metadata trailer; that is acceptable alongside the single `Co-authored-by: Amp` trailer because the thread ID identifies the conversation, not a second agent.
-
-See [AGENTS.md](AGENTS.md) for the agent-attribution rule and its rationale. If you are uncertain which agent is creating the commit, ask — wrong attribution is worse than no attribution.
 
 ## What this repo does NOT require
 

--- a/NODE_UPDATES.md
+++ b/NODE_UPDATES.md
@@ -97,14 +97,6 @@ Do not commit just because the user says "looks good" without "commit" / "procee
 
 ### 10. Create branch and commit
 
-Use the agent-attribution trailer for **whichever agent you are**, per [COMMITS.md](COMMITS.md):
-
-- Claude → `Co-authored-by: Claude <noreply@anthropic.com>`
-- Codex → `Co-authored-by: Codex <codex@openai.com>`
-- Amp → `Co-authored-by: Amp <amp@ampcode.com>` (plus the optional `Amp-Thread-ID:` metadata trailer if your tool emits it)
-
-Exactly one agent trailer per commit — never stack multiple.
-
 Run:
 
 ```bash
@@ -114,8 +106,6 @@ git commit -m "$(cat <<'EOF'
 chore(<package>): bump to v<version>
 
 <release-url>
-
-Co-authored-by: <your-agent-trailer>
 EOF
 )"
 ```
@@ -145,4 +135,3 @@ Print the PR URL. STOP. Do not merge — per [AGENTS.md](AGENTS.md), agents neve
 - For nodes with `sync-config.rs`, consult `.node-updates/approved-config-overrides/<package>.toml` before deciding whether a config diff is already approved or needs human review.
 - Branch name is `release/<package>-<version>` where `<version>` has no leading `v`.
 - Commit subject includes the `v` prefix: `chore(<package>): bump to v<version>`.
-- Use the agent trailer matching **your own** agent tool, not someone else's.

--- a/RULES.md
+++ b/RULES.md
@@ -4,6 +4,12 @@
 
 All project rules, conventions, commands, and architecture info must live in this repo's topic-specific rule files (linked from [AGENTS.md](AGENTS.md)) — never in tool-specific config files (e.g., `CLAUDE.md`, `GEMINI.md`, `COPILOT.md`).
 
-Tool-specific files should only contain a reference to `AGENTS.md` (e.g., `@AGENTS.md`).
+Tool-specific instruction files (e.g., `CLAUDE.md`) must be **symlinks to `AGENTS.md`** so every agent reading either filename receives identical content:
+
+```bash
+ln -s AGENTS.md CLAUDE.md
+```
+
+This is preferred over a one-line `@AGENTS.md` import because Grok and OpenCode do not resolve `@`-imports and would otherwise see literal `@AGENTS.md` text. On Windows checkouts without symlink support (needs Developer Mode or `git config core.symlinks true`), fall back to a `CLAUDE.md` containing only `@AGENTS.md`.
 
 This ensures instructions are shared across all AI agents regardless of which tool is used.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,86 @@
+# Skills
+
+Agent-neutral convention for shipping **agent skills inside this repo** (committable, team-shared — not installable plugins, not host-global) so they work across Claude Code, Codex, OpenCode, Amp, and Grok Build.
+
+This follows the open [Agent Skills specification](https://agentskills.io/specification) and its [client-integration guide](https://agentskills.io/client-implementation/adding-skills-support). Agent-only rules live in [AGENTS.md](AGENTS.md); the documentation-location rule lives in [RULES.md](RULES.md).
+
+## The problem: no single directory is read by all five
+
+Project-scope discovery (verified per vendor docs):
+
+| Agent | `.claude/skills/<name>/` | `.agents/skills/<name>/` |
+|---|---|---|
+| Claude Code | native — the **only** path it reads | — |
+| OpenCode | native | native |
+| Amp | native | native |
+| Grok Build | native (Claude-Code compatibility) | global `~/.agents/` only, not project |
+| Codex | — | native — the **only** path it reads |
+
+`.claude/skills/` covers 4/5 (misses Codex). `.agents/skills/` covers 3/5 at project scope (misses Claude and Grok-project). **No single directory reaches all five**, so a link is unavoidable if we want zero duplication.
+
+## Solution: one real file + one symlink
+
+The spec is [silent on placement](https://agentskills.io/client-implementation/adding-skills-support) — it defines only what goes *inside* a skill dir. The integration guide names `.agents/skills/` the cross-client convention and notes `.claude/skills/` is read "for pragmatic compatibility" by most clients.
+
+We keep the **real** skill under `.claude/skills/` — broadest native coverage (4/5, and the only path Claude Code reads) — and add a **relative symlink** under `.agents/skills/` so Codex reaches the same file:
+
+```
+.claude/skills/<name>/SKILL.md                        # the only real copy
+.agents/skills/<name>  ->  ../../.claude/skills/<name>  # symlink for Codex
+```
+
+Both Claude Code ([docs](https://docs.claude.com/en/docs/claude-code/skills)) and Codex ([docs](https://developers.openai.com/codex/build-skills)) follow symlinked skill directories. The symlink matters **only for Codex**; the other four already read `.claude/skills/` natively. This direction is strictly safer than the reverse: it depends on symlink-following only for Codex (confirmed), never for Grok (undocumented).
+
+### Why not copy — and why no include directive?
+
+- **Copying** the skill into both directories means two files that drift. Rejected.
+- **There is no portable `@include`/import directive** across these agents. `@path` composition is Amp/Claude-specific (documented for `AGENTS.md`, not `SKILL.md` bodies); OpenCode/Codex/Grok ignore it. A symlink — or a single canonical dir, which is impossible here — is the only zero-duplication mechanism. This is why we use a "sublink".
+
+### Dedup / collision (same skill reachable via two roots)
+
+| Agent | behavior |
+|---|---|
+| Claude Code | dedups by target path — loads once |
+| OpenCode | skill names must be unique; a duplicate is shadowed (identical content via the symlink, so harmless) |
+| Amp | first-wins by precedence (`user > .agents > .claude`) |
+| Grok Build | reads only `.claude/skills/` at project scope — sees it once |
+| Codex | reads only `.agents/skills/` — sees it once |
+
+## SKILL.md frontmatter (intersection of all agents)
+
+- `name` — required; must match the directory name; `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤64 chars.
+- `description` — required by all; ≤**1024 chars** (OpenCode cap; Claude allows 1536 — use 1024). Front-load trigger keywords: Codex truncates descriptions to fit ~2% of context.
+
+Avoid Claude-only fields (`paths`, `allowed-tools`, `${CLAUDE_PROJECT_DIR}`, `` !`cmd` ``) in cross-agent skills — OpenCode/Codex/Grok treat them as inert literal text. Use plain repo-root-relative paths in prose.
+
+## Progressive disclosure
+
+Per the [spec](https://agentskills.io/specification): the catalog (`name`+`description`, ~50–100 tokens) loads at session start; the full `SKILL.md` body loads on activation (keep it **<500 lines / <5000 tokens**); bundled scripts/references load on demand. Keep skills small and delegate heavy content to a root doc.
+
+## Authoring rules
+
+1. **Thin wrapper over a root doc.** A skill points at a repo-root topic file (e.g. `NODE_UPDATES.md`) that holds the real workflow; it must not duplicate it. The skill is discovery UX, not the source of truth. This honors [RULES.md](RULES.md).
+2. **No project rules in skill bodies.** Reference the canonical docs; do not restate repo rules.
+3. **Bundled resources** (scripts, references) live next to `SKILL.md`; keep them one level deep.
+4. **Relative paths** resolve against the skill directory (the parent of `SKILL.md`). Both `.claude/skills/<name>/` and `.agents/skills/<name>/` sit three levels below the repo root, so `../../../<root-doc>` resolves correctly through either path — re-verify after any move.
+5. **Skill bodies are operational, not meta.** A `SKILL.md` body loads into context on activation, so every line costs tokens. Put placement/discovery details here in `SKILLS.md`, not in the skill. Follow the [skill-creation best practices](https://agentskills.io/skill-creation/best-practices): add what the agent lacks, omit what it knows, and surface non-obvious project-specific pitfalls in a `## Gotchas` section.
+
+> The spec's "file references one level deep" guidance concerns **bundled skill resources** (scripts/assets shipped with the skill), not a pointer from a thin wrapper to a repo-root document. Pointing up to `NODE_UPDATES.md` is intentional: the workflow keeps one canonical home shared with `AGENTS.md` and human readers.
+
+## Plugin vs in-repo skill
+
+A **plugin** ([Codex](https://developers.openai.com/codex/build-plugins), [anthropics/skills](https://github.com/anthropics/skills)) is an installable, distributable package that may bundle multiple skills + MCP. An **in-repo skill** is a `SKILL.md` committed to the repo and discovered by scanning. Use in-repo skills for workflows tightly coupled to this repo (like `update-node-version`); reserve plugins for cross-repo distribution.
+
+## Verifying discovery
+
+| Agent | how to confirm the skill is loaded |
+|---|---|
+| Claude Code | auto-loads on `description` match |
+| OpenCode | `skill` tool lists it |
+| Codex (CLI/IDE) | `/skills`, or type `$` |
+| Amp | command palette → `skill: list` |
+| Grok Build | `grok inspect`, or `/skills` |
+
+## Current skills
+
+- [`update-node-version`](.claude/skills/update-node-version/SKILL.md) — bump a node from a GitHub release URL; delegates to [NODE_UPDATES.md](NODE_UPDATES.md). Symlinked at `.agents/skills/update-node-version` for Codex.


### PR DESCRIPTION
## Summary

Makes the `update-node-version` skill discoverable and runnable by **Claude Code, Codex, OpenCode, Amp, and Grok** with zero content duplication, and moves agent-attribution policy out of the repo.

Based on primary-source research into each agent's skill-discovery mechanism (links below).

## Cross-agent skill discovery (single source of truth)

The real skill stays in one place; a symlink covers the one agent that can't read it:

```
.claude/skills/update-node-version/SKILL.md   # the only real copy
.agents/skills/update-node-version -> ../../.claude/skills/update-node-version   # symlink for Codex
```

Why this split (verified against each vendor's docs):

| Agent | reads `.claude/skills/` | reads `.agents/skills/` |
|---|---|---|
| Claude Code | native | — |
| OpenCode | native (Claude-compat) | native (agent-compat) |
| Amp | native (Claude-compat) | native (project) |
| Grok Build | native (Claude-compat) | global `~/.agents/` only |
| **Codex** | **—** | **native** |

Codex is the only agent that ignores `.claude/skills/`, and Codex follows symlinks (per its [build-skills docs](https://developers.openai.com/codex/build-skills)). One real file + one pointer = every agent reaches the same `SKILL.md`. The workflow text itself stays in `NODE_UPDATES.md` — the skill is just a thin discovery wrapper.

New `SKILLS.md` documents the convention (discovery matrix, frontmatter intersection across agents, per-agent verification commands) so future skills follow the same pattern.

## De-duplicate agent config (moved to global `AGENTS.md`)

Agent commit-attribution / `Co-authored-by` trailer policy is a **global/local** concern — it already lives in the operator's root `AGENTS.md` and is not specific to this repo. Keeping it here duplicated it across `COMMITS.md`, `AGENTS.md`, `NODE_UPDATES.md`, and the skill. Removed from the repo:

- `COMMITS.md` — the `## Agent Attribution` section.
- `AGENTS.md` — the `## Commit Attribution (agent-only)` section; shared-conventions bullet trimmed.
- `NODE_UPDATES.md` — the per-agent trailer list in step 10, the trailer line in the commit heredoc, and the double-check bullet.
- skill `SKILL.md` — the trailer guidance block.

Net: repo docs only describe repo-specific conventions; per-agent trailer policy is owned where it belongs.

## Verification

- `grep -rniE "co-authored-by|trailer|attribution" *.md` → no matches in repo.
- Symlink resolves: `cat .agents/skills/update-node-version/SKILL.md` returns the real file.
- Frontmatter satisfies all agents' intersection (`name` matches dir; `description` < 1024 chars).

Per-agent skill-load checks: Claude (auto on description match) · OpenCode (`skill` tool) · Codex (`/skills`) · Amp (`skill: list`) · Grok (`grok inspect`).

## Out of scope (not in this PR)

- MCP parity (`.claude.json` `mcpServers` is Claude-only; OpenCode/Amp/Codex each have their own MCP config) — separate concern from skill discovery.

---
PR URL — ready for your review. Not merging per the repo's agent-merge gate.