### PR TITLE
chore(gnosis-geth): bump to v1.17.4-gc

### DIFF
--- a/docker-gnosis-geth/build.toml
+++ b/docker-gnosis-geth/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gnosis-geth"
-version = "1.17.3-gc"
+version = "1.17.4-gc"
 build = "1"
 
 [docker]


### PR DESCRIPTION
https://github.com/gnosischain/go-ethereum/releases/tag/v1.17.4-gc