### PR TITLE
docs(node-updates): auto-create PR, drop human gate

### DIFF
--- a/.claude/skills/update-node-version/SKILL.md
+++ b/.claude/skills/update-node-version/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: update-node-version
-description: Use when the user provides a GitHub release URL for a blockchain node and wants to bump the version in this repo. Extracts version, updates docker-<pkg>/build.toml, treats sync-config.rs output as advisory, and opens a PR after user confirmation.
+description: Use when the user provides a GitHub release URL for a blockchain node and wants to bump the version in this repo. Extracts version, updates docker-<pkg>/build.toml, treats sync-config.rs output as advisory, then commits and opens a PR automatically (never merges).
 ---
 
 # update-node-version
 
-Bump a packaged blockchain node to a new upstream release. The full workflow — URL parsing, mapping lookup, `build.toml` edit, sync-config reconciliation, human gate, branch/commit/PR — lives in [`NODE_UPDATES.md`](../../../NODE_UPDATES.md).
+Bump a packaged blockchain node to a new upstream release. The full workflow — URL parsing, mapping lookup, `build.toml` edit, sync-config reconciliation, branch/commit/PR — lives in [`NODE_UPDATES.md`](../../../NODE_UPDATES.md).
 
-**Read `NODE_UPDATES.md` and follow its workflow exactly.** The human-gate and no-auto-merge rules there are mandatory.
+**Read `NODE_UPDATES.md` and follow its workflow exactly.** The no-auto-merge rule there is mandatory. The workflow commits and opens the PR without a separate confirmation step; genuine ambiguity (config drift outside approved overrides, a non-zero `sync-config.rs`, an existing branch) still triggers a STOP — see steps 4, 6, 7, and 9 of `NODE_UPDATES.md`.
 
 ## Gotchas
 

--- a/NODE_UPDATES.md
+++ b/NODE_UPDATES.md
@@ -15,7 +15,7 @@ If the URL does not match `https://github.com/<org>/<repo>/releases/tag/<tag>`, 
 
 ## Workflow
 
-Follow these steps in order. Do not skip the human gate.
+Follow these steps in order.
 
 ### 1. Parse the URL
 
@@ -87,15 +87,7 @@ Run `git status` and `git diff` and display the output to the user. Summarize wh
 
 If you restored config files after matching approved overrides, say so explicitly. If there were new or changed upstream values outside the approved override record, list them separately and wait for guidance.
 
-### 9. HUMAN GATE — wait for confirmation
-
-STOP and wait for the user to explicitly confirm. Acceptable confirmations: "yes", "proceed", "ship it", "looks good, commit it", "go ahead".
-
-If the user declines or asks for changes, do not commit. Leave the edits on disk so they can adjust.
-
-Do not commit just because the user says "looks good" without "commit" / "proceed" / "ship" — if it's ambiguous, ask.
-
-### 10. Create branch and commit
+### 9. Create branch and commit
 
 Run:
 
@@ -112,7 +104,7 @@ EOF
 
 If `git switch -c` fails because the branch already exists, STOP and ask the user how to proceed.
 
-### 11. Push and open the PR
+### 10. Push and open the PR
 
 Run:
 


### PR DESCRIPTION
## What

Drops the pre-commit human gate from the `update-node-version` workflow so PR creation is mandatory and automatic — the skill now commits and opens a PR on every run instead of stopping to ask "proceed?".

## Why

Operator friction: every version bump required a manual "proceed" before the agent could commit + PR. Version bumps are low-risk and reviewable at PR time. The no-merge rule (AGENTS.md) still gates `main`, so removing the pre-commit gate does not weaken the merge control point.

## Changes

- `NODE_UPDATES.md`: removed step 9 (HUMAN GATE); renumbered former 10/11 → 9/10; dropped the "Do not skip the human gate." line from the workflow header.
- `.claude/skills/update-node-version/SKILL.md`: description now says "commits and opens a PR automatically (never merges)"; body replaced the "human-gate and no-auto-merge rules are mandatory" line with one that keeps only the no-auto-merge rule and lists the remaining genuine-ambiguity STOPs (steps 4, 6, 7, 9).
- Codex reaches the same SKILL.md via the existing `.agents/skills/update-node-version` symlink — no second edit needed.

## What still STOPs (unchanged)

- Step 4: already at the target version.
- Step 6: `sync-config.rs` exits non-zero.
- Step 7: config drift outside `.node-updates/approved-config-overrides/<package>.toml`.
- Step 9: `git switch -c` fails because the release branch already exists.

## Verify locally

- `rg 'human[ -]gate' .` returns no matches.
- Workflow steps are numbered 1–10 with no gaps.
- `mise run build gnosis-geth` (optional) to confirm the build graph still resolves.