### PR TITLE
chore(bsc-geth): bump to v1.7.6

### DIFF
--- a/docker-bsc-geth/build.toml
+++ b/docker-bsc-geth/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsc-geth"
-version = "1.7.3"
+version = "1.7.6"
 build = "1"
 
 [docker]


### PR DESCRIPTION
https://github.com/bnb-chain/bsc/releases/tag/v1.7.6