### PR TITLE
chore(op-node): bump to v1.19.2

### DIFF
--- a/docker-op-node/build.toml
+++ b/docker-op-node/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "op-node"
-version = "1.18.2"
+version = "1.19.2"
 build = "1"
 
 [docker]


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.2