### PR TITLE
chore(heimdall): bump to v0.9.0

### DIFF
--- a/docker-heimdall/build.toml
+++ b/docker-heimdall/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heimdall"
-version = "0.7.1"
+version = "0.9.0"
 build = "1"
 
 [docker]

--- a/docker-heimdall/config/app.toml
+++ b/docker-heimdall/config/app.toml
@@ -130,7 +130,7 @@ datadog-hostname = ""
 enable = true
 
 # Swagger defines if swagger documentation should automatically be registered.
-swagger = true
+swagger = false
 
 # Address defines the API server to listen on.
 address = "tcp://0.0.0.0:1317"
@@ -244,14 +244,20 @@ max-txs = -1
 # RPC endpoint for ethereum chain
 eth_rpc_url = "http://ethereum-geth:8545"
 
-# RPC endpoint for bor chain
+# RPC endpoint(s) for bor chain. Accepts a comma-separated, priority-ordered
+# list for failover (first = primary; heimdall reverts to it once it recovers).
+# A single URL keeps the previous single-endpoint behavior.
 bor_rpc_url = "http://polygon-bor:8945"
 
 # GRPC flag for bor chain
 bor_grpc_flag = "false"
 
-# GRPC endpoint for bor chain
+# GRPC endpoint(s) for bor chain. Like bor_rpc_url, accepts a comma-separated,
+# priority-ordered list for failover.
 bor_grpc_url = "localhost:3131"
+
+# Bearer token for bor gRPC authentication (empty disables auth)
+bor_grpc_token = ""
 
 # RPC endpoint for cometBFT
 comet_bft_rpc_url = "http://0.0.0.0:26657"
@@ -277,11 +283,9 @@ sh_stake_update_interval = "3h0m0s"
 sh_checkpoint_ack_interval = "30m0s"
 sh_max_depth_duration = "24h0m0s"
 
-#### gas limits ####
-main_chain_gas_limit = "5000000"
-
-#### gas price ####
-main_chain_max_gas_price = "400000000000"
+#### gas price configs (EIP-1559) ####
+main_chain_gas_fee_cap = "500000000000"
+main_chain_gas_tip_cap = "10000000000"
 
 ##### Timeout Config #####
 no_ack_wait_time = "30m0s"

--- a/docker-heimdall/config/config.toml
+++ b/docker-heimdall/config/config.toml
@@ -8,7 +8,7 @@
 
 # The version of the CometBFT binary that created or
 # last modified the config file. Do not modify this.
-version = "0.38.19"
+version = "0.38.22"
 
 #######################################################################
 ###                   Main Base Config Options                      ###
@@ -391,6 +391,9 @@ chunk_request_timeout = "10s"
 # The number of concurrent chunk fetchers to run (default: 1).
 chunk_fetchers = "4"
 
+# Maximum number of chunks allowed in a snapshot (default: 100000).
+max_snapshot_chunks = 100000
+
 #######################################################
 ###       Block Sync Configuration Options          ###
 #######################################################
@@ -444,6 +447,20 @@ create_empty_blocks_interval = "0s"
 # Reactor sleep duration parameters
 peer_gossip_sleep_duration = "25ms"
 peer_query_maj23_sleep_duration = "200ms"
+
+# Maximum allowed difference between proposed block time and wall-clock time.
+block_time_tolerance = "1m0s"
+
+# After initial block-sync completes, report catching_up=true when a majority of the
+# connected peers (at least two) are more than this many blocks ahead of us (i.e. this
+# node has stopped keeping up). Set to 0 to disable peer-height lag detection only;
+# must be >=2 when enabled to absorb normal round skew. A node with no peers that is
+# not the sole validator still reports catching_up regardless of this setting.
+catchup_lag_threshold = 5
+
+# How long the peer-lag condition must hold before catching_up flips to true
+# (flap damping). The transition back to false is immediate.
+catchup_debounce_duration = "10s"
 
 #######################################################
 ###         Storage Configuration Options           ###
@@ -518,7 +535,7 @@ initial_block_results_retain_height = 0
 # 		- When "kv" is chosen "tx.height" and "tx.hash" will always be indexed.
 #   3) "psql" - the indexer services backed by PostgreSQL.
 # When "kv" or "psql" is chosen "tx.height" and "tx.hash" will always be indexed.
-indexer = "kv"
+indexer = "null"
 
 # The PostgreSQL connection configuration, the connection format:
 #   postgresql://<user>:<password>@<host>:<port>/<db>?<opts>

--- a/docker-heimdall/sync-config.rs
+++ b/docker-heimdall/sync-config.rs
@@ -49,6 +49,11 @@ struct Args {
     /// Dry run - show what would be executed without running
     #[arg(short = 'n', long)]
     dry_run: bool,
+
+    /// Download and compress the genesis file (~1 GB).
+    /// Skipped by default — only enable when the genesis actually changed.
+    #[arg(long)]
+    with_genesis: bool,
 }
 
 fn main() -> Result<()> {
@@ -157,28 +162,37 @@ fn main() -> Result<()> {
         }
     }
 
-    // Step 4: Download genesis file
-    println!();
-    println!(
-        "{} {}",
-        "→".bold().cyan(),
-        "Downloading genesis file...".bold()
-    );
-    let genesis_path = config_dir.join("genesis.json");
-    download_file(GENESIS_URL, &genesis_path, args.dry_run)?;
+    // Step 4: Download genesis file (opt-in)
+    if args.with_genesis {
+        println!();
+        println!(
+            "{} {}",
+            "→".bold().cyan(),
+            "Downloading genesis file...".bold()
+        );
+        let genesis_path = config_dir.join("genesis.json");
+        download_file(GENESIS_URL, &genesis_path, args.dry_run)?;
 
-    // Step 5: Compress genesis file
-    println!();
-    println!(
-        "{} {}",
-        "→".bold().cyan(),
-        "Compressing genesis file...".bold()
-    );
-    run_command_exit_on_error(
-        &["xz", "-9", &genesis_path.to_string_lossy()],
-        &current_dir,
-        args.dry_run,
-    )?;
+        // Step 5: Compress genesis file
+        println!();
+        println!(
+            "{} {}",
+            "→".bold().cyan(),
+            "Compressing genesis file...".bold()
+        );
+        run_command_exit_on_error(
+            &["xz", "-9", "-f", &genesis_path.to_string_lossy()],
+            &current_dir,
+            args.dry_run,
+        )?;
+    } else {
+        println!();
+        println!(
+            "  {} Genesis download/compression skipped (use {} to enable).",
+            "~".cyan(),
+            "--with-genesis".yellow()
+        );
+    }
 
     println!();
     println!("{}", "━".repeat(60).bright_black());


### PR DESCRIPTION
https://github.com/0xPolygon/heimdall-v2/releases/tag/v0.9.0

Zurich hardfork (mandatory mainnet upgrade).

**Changes:**
- Version 0.7.1 → 0.9.0
- `sync-config.rs`: genesis download/compression now opt-in via `--with-genesis` flag (the genesis.json is ~1 GB; only re-download when it actually changes)
- Config: accepted all upstream defaults (swagger=false, indexer=null, EIP-1559 gas config, new cometbft options); restored 4 approved overrides (eth_rpc_url, bor_rpc_url, seeds, persistent_peers)