### PR TITLE
chore(fraxtal-op-node): bump to v1.19.0-frax-1.2.1

### DIFF
--- a/.node-updates/mappings.toml
+++ b/.node-updates/mappings.toml
@@ -133,3 +133,9 @@ repo = "0xsoniclabs/sonic"
 tag_prefix = ""
 docker_dir = "docker-sonic-geth"
 package = "sonic-geth"
+
+[[mapping]]
+repo = "FraxFinance/fraxtal"
+tag_prefix = ""
+docker_dir = "docker-fraxtal-op-node"
+package = "fraxtal-op-node"

--- a/docker-fraxtal-op-node/build.toml
+++ b/docker-fraxtal-op-node/build.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fraxtal-op-node"
-version = "1.16.9-frax-1.2.1"
-build = "2"
+version = "1.19.0-frax-1.2.1"
+build = "1"
 
 [docker]
 repository = "chainargos/fraxtal-op-node"


### PR DESCRIPTION
https://github.com/FraxFinance/fraxtal/releases/tag/1.19.0-frax-1.2.1