### PR TITLE
chore(mappings): add FraxFinance/fraxtal-op-geth mapping

### DIFF
--- a/.node-updates/mappings.toml
+++ b/.node-updates/mappings.toml
@@ -139,3 +139,9 @@ repo = "FraxFinance/fraxtal"
 tag_prefix = ""
 docker_dir = "docker-fraxtal-op-node"
 package = "fraxtal-op-node"
+
+[[mapping]]
+repo = "FraxFinance/fraxtal-op-geth"
+tag_prefix = ""
+docker_dir = "docker-fraxtal-op-geth"
+package = "fraxtal-op-geth"


### PR DESCRIPTION
Add mapping for `FraxFinance/fraxtal-op-geth` → `docker-fraxtal-op-geth` (package `fraxtal-op-geth`) so future release URLs resolve correctly. Current version `1.101701.0-frax-1.3.0` is already up to date.