### PR TITLE
chore(tron-java): bump to v4.8.1.1

### DIFF
--- a/.node-updates/approved-config-overrides/tron-java.toml
+++ b/.node-updates/approved-config-overrides/tron-java.toml
@@ -1,0 +1,66 @@
+# Approved local overrides for sync-config output in docker-tron-java.
+#
+# Each entry captures a reviewed upstream value and the approved local value
+# that should be restored after running docker-tron-java/sync-config.rs.
+# If a future sync produces a different upstream value for one of these keys,
+# that change should be shown to the user for review.
+
+package = "tron-java"
+docker_dir = "docker-tron-java"
+reviewed_on = "2026-07-14"
+
+[[override]]
+file = "config/main_net_config.conf"
+key = "net.db.engine"
+reviewed_upstream_value = "LEVELDB"
+approved_value = "ROCKSDB"
+reason = "Use RocksDB as the database engine for production performance."
+
+[[override]]
+file = "config/main_net_config.conf"
+key = "node.port.fullNodePort"
+reviewed_upstream_value = 8090
+approved_value = 28090
+reason = "Avoid colliding with the Ethereum geth container's default ports."
+
+[[override]]
+file = "config/main_net_config.conf"
+key = "node.port.solidityPort"
+reviewed_upstream_value = 8091
+approved_value = 28091
+reason = "Avoid colliding with the Ethereum geth container's default ports."
+
+[[override]]
+file = "config/main_net_config.conf"
+key = "node.httpFullNode.httpFullNodeEnable"
+reviewed_upstream_value = "<commented>"
+approved_value = true
+reason = "Enable the HTTP Full Node API so the container exposes it to the docker network."
+
+[[override]]
+file = "config/main_net_config.conf"
+key = "node.httpFullNode.httpFullNodePort"
+reviewed_upstream_value = "<commented>"
+approved_value = 28545
+reason = "Avoid colliding with the Ethereum geth container's default 8545."
+
+[[override]]
+file = "config/main_net_config.conf"
+key = "node.httpFullNode.httpSolidityEnable"
+reviewed_upstream_value = "<commented>"
+approved_value = true
+reason = "Enable the HTTP Solidity API so the container exposes it to the docker network."
+
+[[override]]
+file = "config/main_net_config.conf"
+key = "node.httpFullNode.httpSolidityPort"
+reviewed_upstream_value = "<commented>"
+approved_value = 28555
+reason = "Avoid colliding with other containers' default ports."
+
+[[override]]
+file = "config/main_net_config.conf"
+key = "seed.node.ip.ipv6"
+reviewed_upstream_value = "<commented>"
+approved_value = "<uncommented>"
+reason = "Enable IPv6 seed node addresses for broader peer connectivity."

--- a/.node-updates/mappings.toml
+++ b/.node-updates/mappings.toml
@@ -145,3 +145,9 @@ repo = "FraxFinance/fraxtal-op-geth"
 tag_prefix = ""
 docker_dir = "docker-fraxtal-op-geth"
 package = "fraxtal-op-geth"
+
+[[mapping]]
+repo = "tronprotocol/java-tron"
+tag_prefix = "GreatVoyage-v"
+docker_dir = "docker-tron-java"
+package = "tron-java"

--- a/docker-tron-java/build.toml
+++ b/docker-tron-java/build.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tron-java"
-version = "4.8.1"
-build = "2"
+version = "4.8.1.1"
+build = "1"
 
 [docker]
 repository = "chainargos/tron-java"


### PR DESCRIPTION
https://github.com/tronprotocol/java-tron/releases/tag/GreatVoyage-v4.8.1.1

Code name: Hypatia

**Changes:**
- Version 4.8.1 → 4.8.1.1 (mandatory upgrade)
- Added `tronprotocol/java-tron` mapping (`tag_prefix = "GreatVoyage-v"`)
- Created `approved-config-overrides/tron-java.toml` with 8 local overrides (ROCKSDB engine, non-default ports, HTTP enabled, IPv6 seeds)
- Config restored to approved local values after sync