### PR TITLE
chore(mappings): add celo-org/optimism mapping

### DIFF
--- a/.node-updates/mappings.toml
+++ b/.node-updates/mappings.toml
@@ -87,6 +87,12 @@ docker_dir = "docker-celo-op-geth"
 package = "celo-op-geth"
 
 [[mapping]]
+repo = "celo-org/optimism"
+tag_prefix = "celo-"
+docker_dir = "docker-celo-op-node"
+package = "celo-op-node"
+
+[[mapping]]
 repo = "bitcoin/bitcoin"
 tag_prefix = ""
 docker_dir = "docker-bitcoin-core"


### PR DESCRIPTION
Add mapping for `celo-org/optimism` → `docker-celo-op-node` (package `celo-op-node`, `tag_prefix = "celo-"`) so future release URLs resolve correctly. Current version `2.2.1` is already up to date.