### PR TITLE
chore(celo-op-geth): bump to v2.2.4

### DIFF
--- a/docker-celo-op-geth/build.toml
+++ b/docker-celo-op-geth/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celo-op-geth"
-version = "2.2.3"
+version = "2.2.4"
 build = "1"
 
 [docker]

--- a/docker-celo-op-geth/sync-config.rs
+++ b/docker-celo-op-geth/sync-config.rs
@@ -49,11 +49,16 @@ fn main() -> Result<()> {
     );
     println!("{}", "━".repeat(60).bright_black());
 
-    download_file(
+    if let Err(e) = download_file(
         &format!("{CONFIG_BASE_URL}/genesis.json"),
         &script_dir.join("config/genesis.json").to_string_lossy(),
         args.dry_run,
-    )?;
+    ) {
+        println!(
+            "  {} Genesis download failed (URL may have moved). Keeping existing genesis.json. Error: {e}",
+            "~".yellow()
+        );
+    }
 
     println!();
     println!("{}", "━".repeat(60).bright_black());


### PR DESCRIPTION
https://github.com/celo-org/op-geth/releases/tag/celo-v2.2.4

**Changes:**
- Version 2.2.3 → 2.2.4
- `sync-config.rs`: genesis download is now non-fatal — the upstream `celo-l2-node-docker-compose` repo reorganized and the old genesis URL returns 404. The existing `genesis.json` is stable and kept as-is.