### PR TITLE
chore(ci): update Velnor actions to 2026.8.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@cd0738bd8c56d400b5724efa857dfd9574b4b24a # 2026.8.18
+    uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@af77d84623c0ab38c52ba47b3869c597305369e9 # 2026.8.19
     with:
       lane: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane != '' && inputs.lane) || (github.repository_owner == 'jackin-project' && 'github') || ((github.repository_owner == 'tailrocks' || github.repository_owner == 'ChainArgos') && 'velnor') || 'invalid' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
@@ -119,7 +119,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@f3ae2e43c963ed4034db04902b6233b05f547975 # 2026.8.18
+    uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@22fd17a3ab701f84baa11fb28040127d2096b9d3 # 2026.8.19
     with:
       lane: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane != '' && inputs.lane) || (github.repository_owner == 'jackin-project' && 'github') || ((github.repository_owner == 'tailrocks' || github.repository_owner == 'ChainArgos') && 'velnor') || 'invalid' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
@@ -141,7 +141,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@58eb26c2d6882c2240181d9cabc7eac13b5bf184 # 2026.8.18
+    uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@c425e8a52d00b93f7bdd32c70aa7f552f950ad42 # 2026.8.19
     with:
       lane: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane != '' && inputs.lane) || (github.repository_owner == 'jackin-project' && 'github') || ((github.repository_owner == 'tailrocks' || github.repository_owner == 'ChainArgos') && 'velnor') || 'invalid' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}


### PR DESCRIPTION
Update the generated unified CI consumer to the three signed 2026.8.19 Velnor Actions mirror commits.

Generated workflow only; no repository-local CI divergence.

Signed-off-by: Alexey Zhokhov <alexey@zhokhov.com>
Co-authored-by: Codex <codex@openai.com>