### PR TITLE
ci: roll out Velnor Actions 2026.8.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@af77d84623c0ab38c52ba47b3869c597305369e9 # 2026.8.19
+    uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@805d478d82d7d11f95210451465c4031e0d4a4b2 # 2026.8.20
     with:
       lane: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane != '' && inputs.lane) || (github.repository_owner == 'jackin-project' && 'github') || ((github.repository_owner == 'tailrocks' || github.repository_owner == 'ChainArgos') && 'velnor') || 'invalid' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
@@ -119,7 +119,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@22fd17a3ab701f84baa11fb28040127d2096b9d3 # 2026.8.19
+    uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@eeb2696baaf46ecac5da91b5330fd3f1cce145a4 # 2026.8.20
     with:
       lane: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane != '' && inputs.lane) || (github.repository_owner == 'jackin-project' && 'github') || ((github.repository_owner == 'tailrocks' || github.repository_owner == 'ChainArgos') && 'velnor') || 'invalid' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
@@ -141,7 +141,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@c425e8a52d00b93f7bdd32c70aa7f552f950ad42 # 2026.8.19
+    uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@1fb847dda8ee41ed3796c0798f58fa62cb2973bb # 2026.8.20
     with:
       lane: ${{ (github.event_name == 'workflow_dispatch' && inputs.lane != '' && inputs.lane) || (github.repository_owner == 'jackin-project' && 'github') || ((github.repository_owner == 'tailrocks' || github.repository_owner == 'ChainArgos') && 'velnor') || 'invalid' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}


### PR DESCRIPTION
Generator-rendered rollout of the signed owner-local Velnor Actions `2026.8.20` release. No repository-specific workflow logic is changed.