### PR TITLE
ci: default runner selection to Velnor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,14 @@ on:
   workflow_dispatch:
     inputs:
       lane:
-        description: "Optional CI lane: github, velnor, or both. Empty uses organization default."
+        description: "CI runner: Velnor (default), GitHub, or both. Public unmerged code remains GitHub-hosted."
         required: false
-        type: string
-        default: ""
+        type: choice
+        default: velnor
+        options:
+          - velnor
+          - github
+          - both
       recovery_proof_id:
         description: "Authenticated recovery operation correlation."
         required: false
@@ -99,9 +103,9 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@65899a14f0bf9ccb33458f7873ac21812080c7d5 # 2026.8.22
+    uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@5284c3b23c4873540f75dcf376a802adf3fc9b13 # 2026.8.25
     with:
-      lane: ${{ (github.event_name == 'schedule' && 'both') || (github.event_name == 'workflow_dispatch' && inputs.lane != '' && inputs.lane) || (github.repository_owner == 'jackin-project' && 'github') || ((github.repository_owner == 'tailrocks' || github.repository_owner == 'ChainArgos') && 'velnor') || 'invalid' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lane || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -121,9 +125,9 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@ce26d12afe35cc9f583f50915e13ef0b4e46228b # 2026.8.22
+    uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@d6ebc7863abf5864da0c1a8694d7828d517dbb3b # 2026.8.25
     with:
-      lane: ${{ (github.event_name == 'schedule' && 'both') || (github.event_name == 'workflow_dispatch' && inputs.lane != '' && inputs.lane) || (github.repository_owner == 'jackin-project' && 'github') || ((github.repository_owner == 'tailrocks' || github.repository_owner == 'ChainArgos') && 'velnor') || 'invalid' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lane || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -143,9 +147,9 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@ef2e99579fc69950ef5bf75e139ec4662c0fa4a5 # 2026.8.22
+    uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@a4170e1faad7fe5962d3313968ba1a7e0979c55a # 2026.8.25
     with:
-      lane: ${{ (github.event_name == 'schedule' && 'both') || (github.event_name == 'workflow_dispatch' && inputs.lane != '' && inputs.lane) || (github.repository_owner == 'jackin-project' && 'github') || ((github.repository_owner == 'tailrocks' || github.repository_owner == 'ChainArgos') && 'velnor') || 'invalid' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lane || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}


### PR DESCRIPTION
Adopts signed Velnor Actions 2026.8.25. Trusted automatic runs default to Velnor; workflow dispatch offers Velnor, GitHub, or both. Public unmerged code remains GitHub-hosted.

Verification: generated caller only; actionlint clean.

Signed-off-by: Alexey Zhokhov <donbeave@gmail.com>
Co-authored-by: Codex <codex@openai.com>