### PR TITLE
ci: default all workflows to Velnor lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,11 @@ on:
     - cron: "23 3 * * 0"
   workflow_dispatch:
     inputs:
-      lane:
-        description: "CI runner: Velnor (default), GitHub, or both."
-        required: false
+      lanes:
+        description: velnor (default) | github | both
         type: choice
         default: velnor
-        options:
-          - velnor
-          - github
-          - both
+        options: [velnor, github, both]
       recovery_proof_id:
         description: "Authenticated recovery operation correlation."
         required: false
@@ -105,7 +101,7 @@ jobs:
       pull-requests: read
     uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@052224913aa7c1b6750b8ed34131ae590dd961b1 # 2026.8.28
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lane || 'velnor' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -127,7 +123,7 @@ jobs:
       pull-requests: read
     uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@43fc50c6940beac5a14de96f7e7d7ef3fcac568f # 2026.8.28
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lane || 'velnor' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -149,7 +145,7 @@ jobs:
       pull-requests: read
     uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@034bb3dfca10f405c1f6b89707aa7bc616b7d4db # 2026.8.28
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lane || 'velnor' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -163,14 +159,18 @@ jobs:
       cache_temperature: ${{ inputs.cache_temperature || '' }}
 
   ci-required:
-    name: ci-required
+    name: ci-required (${{ matrix.config.lane }})
     needs:
       - jackin-project
       - tailrocks
       - ChainArgos
     if: ${{ always() }}
-    runs-on: ${{ 'ubuntu-26.04' }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]}]') }}
+    runs-on: ${{ matrix.config.velnor_default_runner }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,6 +2,13 @@ name: DCO
 
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      lanes:
+        description: velnor (default) | github | both
+        type: choice
+        default: velnor
+        options: [velnor, github, both]
 
 permissions:
   contents: read
@@ -12,9 +19,13 @@ concurrency:
 
 jobs:
   dco:
-    name: DCO
-    runs-on: ${{ 'ubuntu-26.04' }}
+    name: DCO (${{ matrix.config.lane }})
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]}]') }}
+    runs-on: ${{ matrix.config.velnor_default_runner }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -26,11 +37,22 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          # Pull requests check the full base..head commit range. Manual
+          # dispatches have no PR range, so they check the head commit only;
+          # the step, toolchain, and lane matrix are identical either way.
+          if [[ -n "${BASE_SHA}" && -n "${HEAD_SHA}" ]]; then
+            range="${BASE_SHA}..${HEAD_SHA}"
+          else
+            range="HEAD~1..HEAD"
+            if ! git rev-parse --verify --quiet HEAD~1 >/dev/null; then
+              range="HEAD"
+            fi
+          fi
           failures=0
           while IFS= read -r commit; do
             if ! git show -s --format=%B "${commit}" | grep -Eiq '^Signed-off-by: .+ <[^>]+>$'; then
               echo "::error::${commit} is missing a Signed-off-by trailer"
               failures=1
             fi
-          done < <(git rev-list --reverse "${BASE_SHA}..${HEAD_SHA}")
+          done < <(git rev-list --reverse "${range}")
           exit "${failures}"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,9 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       lanes:
-        description: |
-          Which runner to run on. Renovate mutates state (opens PRs), so it runs
-          on Velnor by default, GitHub for comparison, or both with GitHub read-only.
+        description: velnor (default) | github | both
         type: choice
         default: velnor
         options: [velnor, github, both]
@@ -27,8 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","runner":["self-hosted","velnor-target-mvp"],"writer":true},{"lane":"GitHub","runner":"ubuntu-26.04","writer":false}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","runner":"ubuntu-26.04","writer":true}]' || '[{"lane":"Velnor","runner":["self-hosted","velnor-target-mvp"],"writer":true}]') }}
-    runs-on: ${{ matrix.config.runner }}
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true}]') }}
+    runs-on: ${{ matrix.config.velnor_default_runner }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 


### PR DESCRIPTION
Convert CI defaults to the Velnor self-hosted fleet with GitHub-hosted fallback parity.

- ci.yml: dispatch input renamed `lane` -> `lanes` (exact fleet contract: `velnor (default) | github | both`); `ci-required` gate now runs on the lane matrix (`velnor_default_runner`) instead of a hard-coded GitHub runner.
- dco.yml: added the exact `lanes` dispatch input and Velnor-default lane matrix; non-PR dispatches check the head commit (same step, same toolchain both lanes).
- renovate.yml: exact `lanes` dispatch description; matrix key renamed to `velnor_default_runner` (writer semantics unchanged).

Default lane (PR/schedule/dispatch) is Velnor `[self-hosted, velnor-target-mvp]`; `lanes=github`/`both` dispatches run identical config on `ubuntu-26.04`. No runner-keyed `if:`, no lane-only steps, no skipped tests.