### PR TITLE
ci: route post-merge push to the GitHub lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       pull-requests: read
     uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@052224913aa7c1b6750b8ed34131ae590dd961b1 # 2026.8.28
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || 'velnor' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'push' && 'github' || 'velnor') }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -123,7 +123,7 @@ jobs:
       pull-requests: read
     uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@43fc50c6940beac5a14de96f7e7d7ef3fcac568f # 2026.8.28
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || 'velnor' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'push' && 'github' || 'velnor') }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -145,7 +145,7 @@ jobs:
       pull-requests: read
     uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@034bb3dfca10f405c1f6b89707aa7bc616b7d4db # 2026.8.28
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || 'velnor' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'push' && 'github' || 'velnor') }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]}]') }}
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]}]') }}
     runs-on: ${{ matrix.config.velnor_default_runner }}
     permissions:
       contents: read

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true}]') }}
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true}]') }}
     runs-on: ${{ matrix.config.velnor_default_runner }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Post-merge push runs failed after #673: the fleet rejects every Velnor job on post-merge push (`Velnor rejected job (merged_push_occupancy)`), e.g. run 32661580427.

Fleet policy: ALL post-merge push routes to the GitHub lane; PR/schedule/dispatch stay Velnor-default.

- ci.yml: `lane=github` passed to the reusable CI on `push`; `ci-required` gate matrix runs the GitHub leg on push.
- renovate.yml: `push` to main runs the GitHub writer leg.

Dispatch lanes contract unchanged; same steps/toolchain on both lanes.