### PR TITLE
chore: sign off Renovate commits for the DCO check

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 20,
   "semanticCommits": "enabled",
+  "commitBody": "Signed-off-by: Don Beave <donbeave@users.noreply.github.com>",
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],


### PR DESCRIPTION
The 8 Renovate PRs opened after the fleet conversion (#675-#682) fail the required `DCO (Velnor)` check: bot commits have no `Signed-off-by` trailer. With `automerge` + required DCO they could never merge.

Root fix: `commitBody` in renovate.json adds the trailer to every Renovate commit. Existing PRs get rebased with signed commits on the next Renovate run.