### PR TITLE
fix: carry Renovate dry-run mode as an explicit matrix field

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true}]') }}
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false,"dry_run":"full"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"}]') }}
     runs-on: ${{ matrix.config.velnor_default_runner }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -35,7 +35,7 @@ jobs:
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
-          RENOVATE_DRY_RUN: ${{ matrix.config.writer && 'false' || 'full' }}
+          RENOVATE_DRY_RUN: ${{ matrix.config.dry_run }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: false
           LOG_LEVEL: debug


### PR DESCRIPTION
Root cause found while verifying the DCO signoff rollout: on the Velnor runner (`Velnor Runner/0.1.177`) the expression `matrix.config.writer && 'false' || 'full'` evaluates to `full` because the string `'false'` is falsy there; GitHub-hosted runners evaluate it to `'false'`. Evidence: scheduled Velnor run 32660284347 logged `RENOVATE_DRY_RUN: full` while the GitHub push leg 32661902380 logged `RENOVATE_DRY_RUN: false`. Every hourly Velnor Renovate run has silently been a dry run.

Fix: explicit `dry_run` field in the lane matrix JSON; `RENOVATE_DRY_RUN: ${{ matrix.config.dry_run }}`. No boolean-string coercion idiom. Writer/lane semantics unchanged.