### PR TITLE
fix: define Renovate env at job level for fleet expression parity

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,6 +27,16 @@ jobs:
       matrix:
         config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false,"dry_run":"full"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"}]') }}
     runs-on: ${{ matrix.config.velnor_default_runner }}
+    env:
+      # Job-level env: the Velnor runner does not evaluate secret-bearing
+      # step-env expressions (they arrive as literal ${{ }} strings), while
+      # job-level env is evaluated before dispatch. Keep every value the
+      # Renovate container needs at job level so both fleets behave the same.
+      RENOVATE_DRY_RUN: ${{ matrix.config.dry_run }}
+      RENOVATE_REPOSITORIES: ${{ github.repository }}
+      RENOVATE_ONBOARDING: false
+      LOG_LEVEL: debug
+      RENOVATE_HOST_RULES: '[{"matchHost":"index.docker.io","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -34,9 +44,3 @@ jobs:
         uses: renovatebot/github-action@316d7cd859606d6039a2182b7d69199e9b036835 # v46.2.1
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
-        env:
-          RENOVATE_DRY_RUN: ${{ matrix.config.dry_run }}
-          RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ONBOARDING: false
-          LOG_LEVEL: debug
-          RENOVATE_HOST_RULES: '[{"matchHost":"index.docker.io","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'


### PR DESCRIPTION
Follow-up to #684. The Velnor writer run then failed to reach Docker Hub: step-level `env` containing secrets is delivered to the Velnor runner as the literal unevaluated `${{ format(...) }}` string (log shows `"val": "${{ format(...) }}"` and `hostRules: []`), so every docker.io lookup was unauthenticated and hit HTTP 429. The GitHub-hosted leg evaluates the same step env correctly — another evaluator divergence like the `'false'`-string one fixed in #684.

Fix: move all Renovate env to job level, the same channel the fleet-canonical consumer already uses for `RENOVATE_TOKEN`; job-level env is evaluated before dispatch on both fleets. Values unchanged.