### PR TITLE
fix: pass Docker Hub credentials as pure RENOVATE_* secret env refs

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -1,17 +1,19 @@
 // Global Renovate configuration for the self-hosted runner fleets.
 //
 // The Velnor runner does not evaluate secret-bearing strings embedded in
-// env values (they arrive as literal ${{ }} expressions), so credentials
-// must reach the container as plain secret environment variables and be
-// assembled here, inside the Renovate process. DOCKERHUB_USERNAME and
-// DOCKERHUB_TOKEN are pure secret references passed through the action's
-// env-regex; repository config stays in renovate.json.
+// env values (they arrive as literal ${{ }} expressions), and the fleet
+// capability manifest forbids the action's configurationFile input, so
+// credentials must reach the container as plain RENOVATE_* secret
+// environment variables (matched by the action's default env passthrough)
+// and be assembled here, inside the Renovate process. The workflow copies
+// this file to /tmp and points RENOVATE_CONFIG_FILE at the copy because
+// the container only mounts /tmp. Repository config stays in renovate.json.
 module.exports = {
   hostRules: [
     {
       matchHost: "index.docker.io",
-      username: process.env.DOCKERHUB_USERNAME,
-      password: process.env.DOCKERHUB_TOKEN,
+      username: process.env.RENOVATE_DOCKERHUB_USERNAME,
+      password: process.env.RENOVATE_DOCKERHUB_TOKEN,
     },
   ],
 };

--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -1,0 +1,17 @@
+// Global Renovate configuration for the self-hosted runner fleets.
+//
+// The Velnor runner does not evaluate secret-bearing strings embedded in
+// env values (they arrive as literal ${{ }} expressions), so credentials
+// must reach the container as plain secret environment variables and be
+// assembled here, inside the Renovate process. DOCKERHUB_USERNAME and
+// DOCKERHUB_TOKEN are pure secret references passed through the action's
+// env-regex; repository config stays in renovate.json.
+module.exports = {
+  hostRules: [
+    {
+      matchHost: "index.docker.io",
+      username: process.env.DOCKERHUB_USERNAME,
+      password: process.env.DOCKERHUB_TOKEN,
+    },
+  ],
+};

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -28,15 +28,16 @@ jobs:
         config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false,"dry_run":"full"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"}]') }}
     runs-on: ${{ matrix.config.velnor_default_runner }}
     env:
-      # Job-level env: the Velnor runner does not evaluate secret-bearing
-      # step-env expressions (they arrive as literal ${{ }} strings), while
-      # job-level env is evaluated before dispatch. Keep every value the
-      # Renovate container needs at job level so both fleets behave the same.
+      # Plain (non-secret) Renovate settings. Secret-bearing strings embedded
+      # in env values are not evaluated by the Velnor runner, so Docker Hub
+      # credentials are passed as pure secret references and assembled into
+      # hostRules inside .github/renovate-config.js instead.
       RENOVATE_DRY_RUN: ${{ matrix.config.dry_run }}
       RENOVATE_REPOSITORIES: ${{ github.repository }}
       RENOVATE_ONBOARDING: false
       LOG_LEVEL: debug
-      RENOVATE_HOST_RULES: '[{"matchHost":"index.docker.io","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -44,3 +45,5 @@ jobs:
         uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682 # v46.2.2
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
+          configurationFile: .github/renovate-config.js
+          env-regex: '^(?:RENOVATE_\w+|LOG_LEVEL|DOCKERHUB_\w+|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -29,21 +29,26 @@ jobs:
     runs-on: ${{ matrix.config.velnor_default_runner }}
     env:
       # Plain (non-secret) Renovate settings. Secret-bearing strings embedded
-      # in env values are not evaluated by the Velnor runner, so Docker Hub
-      # credentials are passed as pure secret references and assembled into
-      # hostRules inside .github/renovate-config.js instead.
+      # in env values are not evaluated by the Velnor runner, and the fleet
+      # capability manifest forbids the action's configurationFile/env-regex
+      # inputs, so Docker Hub credentials travel as pure RENOVATE_* secret
+      # references (matched by the action's default env passthrough) and are
+      # assembled into hostRules by /tmp/renovate-config.js inside the
+      # container.
       RENOVATE_DRY_RUN: ${{ matrix.config.dry_run }}
       RENOVATE_REPOSITORIES: ${{ github.repository }}
       RENOVATE_ONBOARDING: false
+      RENOVATE_CONFIG_FILE: /tmp/renovate-config.js
       LOG_LEVEL: debug
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      RENOVATE_DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      RENOVATE_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Stage Renovate global config on the shared /tmp mount
+        run: install -m 0644 .github/renovate-config.js /tmp/renovate-config.js
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682 # v46.2.2
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
-          configurationFile: .github/renovate-config.js
-          env-regex: '^(?:RENOVATE_\w+|LOG_LEVEL|DOCKERHUB_\w+|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$'


### PR DESCRIPTION
Third and final Renovate-on-Velnor fix (after #684, #685):

- The Velnor runner never evaluates env strings with embedded secrets (literal `${{ format(...) }}` reaches the job), at step OR job level.
- The fleet capability manifest (v9) rejects the action's `configurationFile`/`env-regex` inputs — only `token`, `renovate-version`, `renovate-image` are accepted (verified: run 32664188328 rejected with the exact allowlist).

Working channel, verified by test dispatch run 32664343869 from this branch: pure `RENOVATE_DOCKERHUB_*` secret env refs evaluate on Velnor (masked `***` in logs), match the action's default container env passthrough regex, and the committed `.github/renovate-config.js` — staged to the shared `/tmp` mount by a plain run step and referenced via non-secret `RENOVATE_CONFIG_FILE` — assembles the Docker Hub `hostRules` inside the Renovate process. Zero Docker Hub 429s in the test run, and it rebased PRs #675-#682 with the DCO signoff from #683. No secrets committed.