### PR TITLE
fix(ci): re-pin renovatebot/github-action to admitted v46.2.3 digest

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -49,6 +49,6 @@ jobs:
         run: install -m 0644 .github/renovate-config.js /tmp/renovate-config.js
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
+        uses: renovatebot/github-action@0a7b68676027570f113b1d6e7b69b231b56167ab # v46.2.3
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Why

Scheduled Renovate runs on main are red since PR #687 merged digest `5402b206248e5a8c8427a15102702eb9c1793efc` (v46.2.4). The Velnor fleet rejects the job at `capability_validation`:

> unsupported capability in step 'Self-hosted Renovate': action renovatebot/github-action@5402b206…, accepted: 0a7b686… (v46.2.3), e09d604… (v46.2.2), …

## What

Re-pin to the highest admitted digest `0a7b68676027570f113b1d6e7b69b231b56167ab` (v46.2.3). Root-consistent: the fleet cannot run unadmitted pins.

## Note

v46.2.4 needs admit-then-release (capability manifest admit + fleet release) before the next Renovate bump PR for this action can merge. Renovate will re-open the bump; it should be held until the fleet admits the digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)