### PR TITLE
fix(ci): re-pin renovatebot/github-action to manifest-admitted v46.2.3 and gate its automerge

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -49,6 +49,6 @@ jobs:
         run: install -m 0644 .github/renovate-config.js /tmp/renovate-config.js
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
+        uses: renovatebot/github-action@0a7b68676027570f113b1d6e7b69b231b56167ab # v46.2.3
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,24 @@
   "commitBody": "Signed-off-by: Don Beave <donbeave@users.noreply.github.com>",
   "packageRules": [
     {
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "renovatebot/github-action"
+      ],
+      "automerge": false,
+      "description": "Fleet capability manifest admits action digests with a lag; manual merge only after the Velnor manifest admits the new digest"
     }
   ]
 }


### PR DESCRIPTION
Root cause: the Velnor fleet capability manifest (version 9) admits renovatebot/github-action digests only up to v46.2.3 (`0a7b686`). The blanket renovate automerge merged the v46.2.4 bump (#692) directly to main; every scheduled Velnor-lane Renovate run since fails `capability_validation` (unsupported action ref), leaving main red while the GitHub lane stays green.

This is the second lap of the loop (#691 re-pinned, #692 re-bumped), so the structural fix is included: `renovatebot/github-action` is excluded from automerge. Future bumps still get PRs, but merge manually once the Velnor manifest admits the new digest.

- Re-pin `.github/workflows/renovate.yml` to v46.2.3 (`0a7b68676027570f113b1d6e7b69b231b56167ab`, manifest-admitted)
- Add renovate.json packageRule: `automerge: false` for `renovatebot/github-action`

Deferred root cause (cross-repo): velnor manifest does not yet admit v46.2.4 (`5402b206`); admitting it requires a velnor manifest bump + release + fleet deploy.