### PR TITLE
ci(docker): restore affected image publishing

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -68,7 +68,7 @@ jobs:
           while IFS= read -r path; do
             [ -z "${path}" ] && continue
             case "${path}" in
-              docker-build.rs|docker-exists.rs|mise.toml|Cargo.toml|Cargo.lock|.github/workflows/build-publish.yml)
+              docker-build.rs|docker-exists.rs|mise.toml|Cargo.toml|Cargo.lock)
                 all=true
                 ;;
               docker-debian-blockchain-base/*)
@@ -92,7 +92,7 @@ jobs:
                   fi
                 done
                 ;;
-              README.md|README.*|**/*.md|RULES.md|BRANCHING.md|COMMITS.md|BUILD_SYSTEM.md|NODE_UPDATES.md|SKILLS.md|docker-compose.yml|.node-updates/*|.node-updates/**|.github/AGENTS.md|.github/workflows/ci.yml|.github/workflows/dco.yml|.github/workflows/renovate.yml|.github/renovate-config.js)
+              README.md|README.*|**/*.md|RULES.md|BRANCHING.md|COMMITS.md|BUILD_SYSTEM.md|NODE_UPDATES.md|SKILLS.md|docker-compose.yml|.node-updates/*|.node-updates/**|.github/AGENTS.md|.github/workflows/ci.yml|.github/workflows/dco.yml|.github/workflows/renovate.yml|.github/workflows/build-publish.yml|.github/renovate-config.js)
                 ;;
               docker-*)
                 package="${path#docker-}"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -202,17 +202,30 @@ jobs:
             echo "Failed to check ${PACKAGE} on Docker Hub; refusing to guess" >&2
             exit 1
           fi
-          partial=false
+          platform_count=0
+          platforms_found=0
           for platform in ${platforms}; do
+            platform_count=$((platform_count + 1))
             if ! platform_exists="$("${exists_cmd[@]}" --platform "${platform}" "${PACKAGE}")"; then
               echo "Failed to check ${PACKAGE}:${platform} on Docker Hub; refusing to guess" >&2
               exit 1
             fi
-            if [ "${platform_exists}" = "true" ]; then
-              partial=true
-            fi
+            case "${platform_exists}" in
+              true) platforms_found=$((platforms_found + 1)) ;;
+              false) ;;
+              *) echo "Invalid Docker Hub response for ${PACKAGE}:${platform}; refusing to guess" >&2; exit 1 ;;
+            esac
           done
-          if [ "${partial}" = "true" ] && [ "${manifest_exists}" != "true" ]; then
+          if [ "${platform_count}" -eq 0 ]; then
+            echo "No platforms configured for ${PACKAGE}; refusing to guess" >&2
+            exit 1
+          elif [ "${manifest_exists}" != "true" ] && [ "${manifest_exists}" != "false" ]; then
+            echo "Invalid Docker Hub response for ${PACKAGE}; refusing to guess" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "true" ] && [ "${platforms_found}" -ne "${platform_count}" ]; then
+            echo "${PACKAGE} manifest exists but platform tags are incomplete; refusing to overwrite it" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "false" ] && [ "${platforms_found}" -ne 0 ]; then
             echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
             exit 1
           elif [ "${manifest_exists}" = "true" ] && [ "${FORCE_BUILD}" = "true" ] && [ "${MANUAL_DISPATCH}" != "true" ]; then
@@ -295,17 +308,30 @@ jobs:
             echo "Failed to check ${PACKAGE} on Docker Hub; refusing to guess" >&2
             exit 1
           fi
-          partial=false
+          platform_count=0
+          platforms_found=0
           for platform in ${platforms}; do
+            platform_count=$((platform_count + 1))
             if ! platform_exists="$("${exists_cmd[@]}" --platform "${platform}" "${PACKAGE}")"; then
               echo "Failed to check ${PACKAGE}:${platform} on Docker Hub; refusing to guess" >&2
               exit 1
             fi
-            if [ "${platform_exists}" = "true" ]; then
-              partial=true
-            fi
+            case "${platform_exists}" in
+              true) platforms_found=$((platforms_found + 1)) ;;
+              false) ;;
+              *) echo "Invalid Docker Hub response for ${PACKAGE}:${platform}; refusing to guess" >&2; exit 1 ;;
+            esac
           done
-          if [ "${partial}" = "true" ] && [ "${manifest_exists}" != "true" ]; then
+          if [ "${platform_count}" -eq 0 ]; then
+            echo "No platforms configured for ${PACKAGE}; refusing to guess" >&2
+            exit 1
+          elif [ "${manifest_exists}" != "true" ] && [ "${manifest_exists}" != "false" ]; then
+            echo "Invalid Docker Hub response for ${PACKAGE}; refusing to guess" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "true" ] && [ "${platforms_found}" -ne "${platform_count}" ]; then
+            echo "${PACKAGE} manifest exists but platform tags are incomplete; refusing to overwrite it" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "false" ] && [ "${platforms_found}" -ne 0 ]; then
             echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
             exit 1
           elif [ "${manifest_exists}" = "true" ] && [ "${FORCE_BUILD}" = "true" ] && [ "${MANUAL_DISPATCH}" != "true" ]; then
@@ -386,14 +412,34 @@ jobs:
           set -euo pipefail
           platforms=$(sed -n 's/^platforms = \[\(.*\)\]/\1/p' "docker-${PACKAGE}/build.toml" | tr -d '"' | tr ',' ' ')
           exists_cmd=(rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs)
-          manifest_exists="$("${exists_cmd[@]}" "${PACKAGE}")"
-          partial=false
+          if ! manifest_exists="$("${exists_cmd[@]}" "${PACKAGE}")"; then
+            echo "Failed to check ${PACKAGE} on Docker Hub; refusing to guess" >&2
+            exit 1
+          fi
+          platform_count=0
+          platforms_found=0
           for platform in ${platforms}; do
-            if [ "$("${exists_cmd[@]}" --platform "${platform}" "${PACKAGE}")" = "true" ]; then
-              partial=true
+            platform_count=$((platform_count + 1))
+            if ! platform_exists="$("${exists_cmd[@]}" --platform "${platform}" "${PACKAGE}")"; then
+              echo "Failed to check ${PACKAGE}:${platform} on Docker Hub; refusing to guess" >&2
+              exit 1
             fi
+            case "${platform_exists}" in
+              true) platforms_found=$((platforms_found + 1)) ;;
+              false) ;;
+              *) echo "Invalid Docker Hub response for ${PACKAGE}:${platform}; refusing to guess" >&2; exit 1 ;;
+            esac
           done
-          if [ "${partial}" = "true" ] && [ "${manifest_exists}" != "true" ]; then
+          if [ "${platform_count}" -eq 0 ]; then
+            echo "No platforms configured for ${PACKAGE}; refusing to guess" >&2
+            exit 1
+          elif [ "${manifest_exists}" != "true" ] && [ "${manifest_exists}" != "false" ]; then
+            echo "Invalid Docker Hub response for ${PACKAGE}; refusing to guess" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "true" ] && [ "${platforms_found}" -ne "${platform_count}" ]; then
+            echo "${PACKAGE} manifest exists but platform tags are incomplete; refusing to overwrite it" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "false" ] && [ "${platforms_found}" -ne 0 ]; then
             echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
             exit 1
           elif [ "${manifest_exists}" = "true" ] && [ "${MANUAL_DISPATCH}" = "true" ]; then

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -178,7 +178,7 @@ jobs:
 
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
-          install_args: "cargo:rust-script"
+          install_args: "rust cargo:rust-script"
 
       - name: Cache rust-script
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -265,7 +265,7 @@ jobs:
 
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
-          install_args: "cargo:rust-script"
+          install_args: "rust cargo:rust-script"
 
       - name: Cache rust-script
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -355,7 +355,7 @@ jobs:
 
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
-          install_args: "cargo:rust-script"
+          install_args: "rust cargo:rust-script"
 
       - name: Cache rust-script
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,369 @@
+name: Docker Build and Publish
+
+# Builds each affected docker-* package in its own matrix job. Docker Hub
+# publication happens from the writer lane; the read-only lane in a `both`
+# run validates the same build plan without pushing.
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      lanes:
+        description: Which runner lane(s) should execute the build
+        type: choice
+        default: velnor
+        options: [velnor, github, both]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  BUILDX_CACHE: registry
+
+jobs:
+  select:
+    name: Select affected Docker packages
+    runs-on: ubuntu-26.04
+    timeout-minutes: 10
+    outputs:
+      packages: ${{ steps.select.outputs.packages }}
+      work_required: ${{ steps.select.outputs.work_required }}
+      force_base: ${{ steps.select.outputs.force_base }}
+      force_build: ${{ steps.select.outputs.force_build }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Select affected packages
+        id: select
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            changed=$(git ls-files)
+          elif [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            changed=$(git ls-files)
+          else
+            changed=$(git diff --name-only "${BEFORE_SHA}" "${CURRENT_SHA}")
+          fi
+
+          declare -A affected=()
+          all=false
+          force_base=false
+          force_build=false
+
+          while IFS= read -r path; do
+            [ -z "${path}" ] && continue
+            case "${path}" in
+              docker-build.rs|docker-exists.rs|mise.toml|Cargo.toml|Cargo.lock|.github/workflows/build-publish.yml)
+                all=true
+                ;;
+              docker-debian-blockchain-base/*)
+                affected[debian-blockchain-base]=1
+                force_base=true
+                force_build=true
+                for build_toml in docker-*/build.toml; do
+                  package="${build_toml#docker-}"
+                  package="${package%/build.toml}"
+                  affected["${package}"]=1
+                done
+                ;;
+              docker-debian-blockchain-build/*)
+                affected[debian-blockchain-build]=1
+                force_build=true
+                for dockerfile in docker-*/Dockerfile; do
+                  package="${dockerfile#docker-}"
+                  package="${package%/Dockerfile}"
+                  if rg -q '^FROM chainargos/debian-blockchain-build:' "${dockerfile}"; then
+                    affected["${package}"]=1
+                  fi
+                done
+                ;;
+              README.md|README.*|**/*.md|RULES.md|BRANCHING.md|COMMITS.md|BUILD_SYSTEM.md|NODE_UPDATES.md|SKILLS.md|docker-compose.yml|.node-updates/*|.node-updates/**|.github/AGENTS.md|.github/workflows/ci.yml|.github/workflows/dco.yml|.github/workflows/renovate.yml|.github/renovate-config.js)
+                ;;
+              docker-*)
+                package="${path#docker-}"
+                package="${package%%/*}"
+                if [ -f "docker-${package}/build.toml" ]; then
+                  affected["${package}"]=1
+                  case "${package}" in
+                    debian-blockchain-base)
+                      force_base=true
+                      force_build=true
+                      ;;
+                    debian-blockchain-build)
+                      force_build=true
+                      ;;
+                  esac
+                else
+                  all=true
+                fi
+                ;;
+              *)
+                all=true
+                ;;
+            esac
+          done <<< "${changed}"
+
+          if [ "${all}" = true ]; then
+            for build_toml in docker-*/build.toml; do
+              package="${build_toml#docker-}"
+              package="${package%/build.toml}"
+              affected["${package}"]=1
+            done
+            force_base=true
+            force_build=true
+          fi
+
+          leaf_packages=()
+          for package in "${!affected[@]}"; do
+            case "${package}" in
+              debian-blockchain-base|debian-blockchain-build) ;;
+              *) leaf_packages+=("${package}") ;;
+            esac
+          done
+
+          if [ "${#leaf_packages[@]}" -eq 0 ] && [ "${force_base}" = false ] && [ "${force_build}" = false ]; then
+            work_required=false
+            packages='[]'
+          else
+            work_required=true
+            packages=$(printf '%s\n' "${leaf_packages[@]}" | sort | jq -Rsc 'split("\n") | map(select(length > 0))')
+          fi
+
+          echo "packages=${packages}" >> "${GITHUB_OUTPUT}"
+          echo "work_required=${work_required}" >> "${GITHUB_OUTPUT}"
+          echo "force_base=${force_base}" >> "${GITHUB_OUTPUT}"
+          echo "force_build=${force_build}" >> "${GITHUB_OUTPUT}"
+          echo "packages=${packages}"
+          echo "work_required=${work_required}"
+          echo "force_base=${force_base}"
+          echo "force_build=${force_build}"
+
+  base:
+    needs: select
+    if: needs.select.outputs.work_required == 'true'
+    name: docker-debian-blockchain-base (${{ matrix.config.lane }})
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","runner":["self-hosted","velnor-target-mvp"],"writer":true},{"lane":"GitHub","runner":"ubuntu-26.04","writer":false}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","runner":"ubuntu-26.04","writer":true}]' || '[{"lane":"Velnor","runner":["self-hosted","velnor-target-mvp"],"writer":true}]') }}
+    runs-on: ${{ matrix.config.runner }}
+    timeout-minutes: 45
+    concurrency:
+      group: docker-build-${{ matrix.config.lane }}-debian-blockchain-base
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install_args: "cargo:rust-script"
+
+      - name: Cache rust-script
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/rust-script
+          key: rust-script-${{ matrix.config.lane }}-${{ runner.os }}-v1-${{ hashFiles('docker-*.rs', 'containerctl.rs', 'docker-*/**/*.rs', 'mise.toml') }}
+          restore-keys: |
+            rust-script-${{ matrix.config.lane }}-${{ runner.os }}-
+
+      - name: Check base image
+        id: check-image
+        env:
+          FORCE_BUILD: ${{ needs.select.outputs.force_base }}
+        run: |
+          if [ "${FORCE_BUILD}" = "true" ] || [ "$(mise run exists debian-blockchain-base)" != "true" ]; then
+            echo "needs-build=true" >> "${GITHUB_OUTPUT}"
+            echo "debian-blockchain-base will be built"
+          else
+            echo "needs-build=false" >> "${GITHUB_OUTPUT}"
+            echo "debian-blockchain-base already exists and is unaffected"
+          fi
+
+      - name: Login to Docker Hub
+        if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Set up QEMU
+        if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Initialize Docker Buildx
+        if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          name: bcn-ci
+          driver: docker-container
+          install: "true"
+
+      - name: Build Docker image
+        if: steps.check-image.outputs.needs-build == 'true'
+        run: mise run ${{ matrix.config.writer && 'build' || 'build-dry' }} debian-blockchain-base
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    needs: [select, base]
+    if: needs.select.outputs.work_required == 'true'
+    name: docker-debian-blockchain-build (${{ matrix.config.lane }})
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","runner":["self-hosted","velnor-target-mvp"],"writer":true},{"lane":"GitHub","runner":"ubuntu-26.04","writer":false}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","runner":"ubuntu-26.04","writer":true}]' || '[{"lane":"Velnor","runner":["self-hosted","velnor-target-mvp"],"writer":true}]') }}
+    runs-on: ${{ matrix.config.runner }}
+    timeout-minutes: 45
+    concurrency:
+      group: docker-build-${{ matrix.config.lane }}-debian-blockchain-build
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install_args: "cargo:rust-script"
+
+      - name: Cache rust-script
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/rust-script
+          key: rust-script-${{ matrix.config.lane }}-${{ runner.os }}-v1-${{ hashFiles('docker-*.rs', 'containerctl.rs', 'docker-*/**/*.rs', 'mise.toml') }}
+          restore-keys: |
+            rust-script-${{ matrix.config.lane }}-${{ runner.os }}-
+
+      - name: Check build image
+        id: check-image
+        env:
+          FORCE_BUILD: ${{ needs.select.outputs.force_build }}
+        run: |
+          if [ "${FORCE_BUILD}" = "true" ] || [ "$(mise run exists debian-blockchain-build)" != "true" ]; then
+            echo "needs-build=true" >> "${GITHUB_OUTPUT}"
+            echo "debian-blockchain-build will be built"
+          else
+            echo "needs-build=false" >> "${GITHUB_OUTPUT}"
+            echo "debian-blockchain-build already exists and is unaffected"
+          fi
+
+      - name: Login to Docker Hub
+        if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Set up QEMU
+        if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Initialize Docker Buildx
+        if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          name: bcn-ci
+          driver: docker-container
+          install: "true"
+
+      - name: Build Docker image
+        if: steps.check-image.outputs.needs-build == 'true'
+        run: mise run ${{ matrix.config.writer && 'build' || 'build-dry' }} debian-blockchain-build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  packages:
+    needs: [select, build]
+    if: needs.select.outputs.packages != '[]'
+    name: docker-${{ matrix.package }} (${{ matrix.config.lane }})
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","runner":["self-hosted","velnor-target-mvp"],"writer":true},{"lane":"GitHub","runner":"ubuntu-26.04","writer":false}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","runner":"ubuntu-26.04","writer":true}]' || '[{"lane":"Velnor","runner":["self-hosted","velnor-target-mvp"],"writer":true}]') }}
+        package: ${{ fromJSON(needs.select.outputs.packages) }}
+    runs-on: ${{ matrix.config.runner }}
+    timeout-minutes: 180
+    concurrency:
+      group: docker-build-${{ matrix.config.lane }}-${{ matrix.package }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # docker-heimdall ships a 235 MB genesis file through Git LFS.
+          lfs: ${{ matrix.package == 'heimdall' }}
+
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install_args: "cargo:rust-script"
+
+      - name: Cache rust-script
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/rust-script
+          key: rust-script-${{ matrix.config.lane }}-${{ runner.os }}-v1-${{ hashFiles('docker-*.rs', 'containerctl.rs', 'docker-*/**/*.rs', 'mise.toml') }}
+          restore-keys: |
+            rust-script-${{ matrix.config.lane }}-${{ runner.os }}-
+
+      - name: Check target image
+        id: check-image
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          platforms=$(sed -n 's/^platforms = \[\(.*\)\]/\1/p' "docker-${PACKAGE}/build.toml" | tr -d '"' | tr ',' ' ')
+          exists_cmd=(rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs)
+          manifest_exists="$("${exists_cmd[@]}" "${PACKAGE}")"
+          partial=false
+          for platform in ${platforms}; do
+            if [ "$("${exists_cmd[@]}" --platform "${platform}" "${PACKAGE}")" = "true" ]; then
+              partial=true
+            fi
+          done
+          if [ "${manifest_exists}" = "true" ]; then
+            echo "needs-build=false" >> "${GITHUB_OUTPUT}"
+            echo "${PACKAGE} is already published; skipping overwrite"
+          elif [ "${partial}" = "true" ]; then
+            echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
+            exit 1
+          else
+            echo "needs-build=true" >> "${GITHUB_OUTPUT}"
+            echo "${PACKAGE} is affected and will be built"
+          fi
+
+      - name: Login to Docker Hub
+        if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Set up QEMU
+        if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Initialize Docker Buildx
+        if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          name: bcn-ci
+          driver: docker-container
+          install: "true"
+
+      - name: Build and publish Docker image
+        if: steps.check-image.outputs.needs-build == 'true'
+        run: mise run ${{ matrix.config.writer && 'build' || 'build-dry' }} "${PACKAGE}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE: ${{ matrix.package }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -71,6 +71,8 @@ jobs:
               docker-build.rs|docker-exists.rs|mise.toml|Cargo.toml|Cargo.lock)
                 all=true
                 ;;
+              README.md|README.*|**/*.md|RULES.md|BRANCHING.md|COMMITS.md|BUILD_SYSTEM.md|NODE_UPDATES.md|SKILLS.md|docker-compose.yml|.node-updates/*|.node-updates/**|.github/AGENTS.md|.github/workflows/ci.yml|.github/workflows/dco.yml|.github/workflows/renovate.yml|.github/workflows/build-publish.yml|.github/renovate-config.js|containerctl.rs|LICENSE|renovate.json)
+                ;;
               docker-debian-blockchain-base/*)
                 affected[debian-blockchain-base]=1
                 force_base=true
@@ -91,8 +93,6 @@ jobs:
                     affected["${package}"]=1
                   fi
                 done
-                ;;
-              README.md|README.*|**/*.md|RULES.md|BRANCHING.md|COMMITS.md|BUILD_SYSTEM.md|NODE_UPDATES.md|SKILLS.md|docker-compose.yml|.node-updates/*|.node-updates/**|.github/AGENTS.md|.github/workflows/ci.yml|.github/workflows/dco.yml|.github/workflows/renovate.yml|.github/workflows/build-publish.yml|.github/renovate-config.js)
                 ;;
               docker-*)
                 package="${path#docker-}"
@@ -187,14 +187,38 @@ jobs:
       - name: Check base image
         id: check-image
         env:
+          PACKAGE: debian-blockchain-base
           FORCE_BUILD: ${{ needs.select.outputs.force_base }}
         run: |
-          if [ "${FORCE_BUILD}" = "true" ] || [ "$(mise run exists debian-blockchain-base)" != "true" ]; then
-            echo "needs-build=true" >> "${GITHUB_OUTPUT}"
-            echo "debian-blockchain-base will be built"
-          else
+          set -euo pipefail
+          platforms=$(sed -n 's/^platforms = \[\(.*\)\]/\1/p' "docker-${PACKAGE}/build.toml" | tr -d '"' | tr ',' ' ')
+          exists_cmd=(rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs)
+          if ! manifest_exists="$("${exists_cmd[@]}" "${PACKAGE}")"; then
+            echo "Failed to check ${PACKAGE} on Docker Hub; refusing to guess" >&2
+            exit 1
+          fi
+          partial=false
+          for platform in ${platforms}; do
+            if ! platform_exists="$("${exists_cmd[@]}" --platform "${platform}" "${PACKAGE}")"; then
+              echo "Failed to check ${PACKAGE}:${platform} on Docker Hub; refusing to guess" >&2
+              exit 1
+            fi
+            if [ "${platform_exists}" = "true" ]; then
+              partial=true
+            fi
+          done
+          if [ "${partial}" = "true" ] && [ "${manifest_exists}" != "true" ]; then
+            echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "true" ] && [ "${FORCE_BUILD}" = "true" ]; then
+            echo "${PACKAGE} is affected but its tag already exists; bump package.version or package.build" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "true" ]; then
+            echo "${PACKAGE} already exists and is unaffected; skipping build"
             echo "needs-build=false" >> "${GITHUB_OUTPUT}"
-            echo "debian-blockchain-base already exists and is unaffected"
+          else
+            echo "needs-build=true" >> "${GITHUB_OUTPUT}"
+            echo "${PACKAGE} will be built"
           fi
 
       - name: Login to Docker Hub
@@ -253,14 +277,38 @@ jobs:
       - name: Check build image
         id: check-image
         env:
+          PACKAGE: debian-blockchain-build
           FORCE_BUILD: ${{ needs.select.outputs.force_build }}
         run: |
-          if [ "${FORCE_BUILD}" = "true" ] || [ "$(mise run exists debian-blockchain-build)" != "true" ]; then
-            echo "needs-build=true" >> "${GITHUB_OUTPUT}"
-            echo "debian-blockchain-build will be built"
-          else
+          set -euo pipefail
+          platforms=$(sed -n 's/^platforms = \[\(.*\)\]/\1/p' "docker-${PACKAGE}/build.toml" | tr -d '"' | tr ',' ' ')
+          exists_cmd=(rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs)
+          if ! manifest_exists="$("${exists_cmd[@]}" "${PACKAGE}")"; then
+            echo "Failed to check ${PACKAGE} on Docker Hub; refusing to guess" >&2
+            exit 1
+          fi
+          partial=false
+          for platform in ${platforms}; do
+            if ! platform_exists="$("${exists_cmd[@]}" --platform "${platform}" "${PACKAGE}")"; then
+              echo "Failed to check ${PACKAGE}:${platform} on Docker Hub; refusing to guess" >&2
+              exit 1
+            fi
+            if [ "${platform_exists}" = "true" ]; then
+              partial=true
+            fi
+          done
+          if [ "${partial}" = "true" ] && [ "${manifest_exists}" != "true" ]; then
+            echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "true" ] && [ "${FORCE_BUILD}" = "true" ]; then
+            echo "${PACKAGE} is affected but its tag already exists; bump package.version or package.build" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "true" ]; then
+            echo "${PACKAGE} already exists and is unaffected; skipping build"
             echo "needs-build=false" >> "${GITHUB_OUTPUT}"
-            echo "debian-blockchain-build already exists and is unaffected"
+          else
+            echo "needs-build=true" >> "${GITHUB_OUTPUT}"
+            echo "${PACKAGE} will be built"
           fi
 
       - name: Login to Docker Hub
@@ -334,11 +382,11 @@ jobs:
               partial=true
             fi
           done
-          if [ "${manifest_exists}" = "true" ]; then
-            echo "needs-build=false" >> "${GITHUB_OUTPUT}"
-            echo "${PACKAGE} is already published; skipping overwrite"
-          elif [ "${partial}" = "true" ]; then
+          if [ "${partial}" = "true" ] && [ "${manifest_exists}" != "true" ]; then
             echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
+            exit 1
+          elif [ "${manifest_exists}" = "true" ]; then
+            echo "${PACKAGE} is affected but its tag already exists; bump package.version or package.build" >&2
             exit 1
           else
             echo "needs-build=true" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -35,6 +35,7 @@ jobs:
       work_required: ${{ steps.select.outputs.work_required }}
       force_base: ${{ steps.select.outputs.force_base }}
       force_build: ${{ steps.select.outputs.force_build }}
+      manual_dispatch: ${{ steps.select.outputs.manual_dispatch }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -52,7 +53,9 @@ jobs:
         run: |
           set -euo pipefail
 
+          manual_dispatch=false
           if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            manual_dispatch=true
             changed=$(git ls-files)
           elif [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
             changed=$(git ls-files)
@@ -148,6 +151,7 @@ jobs:
           echo "work_required=${work_required}" >> "${GITHUB_OUTPUT}"
           echo "force_base=${force_base}" >> "${GITHUB_OUTPUT}"
           echo "force_build=${force_build}" >> "${GITHUB_OUTPUT}"
+          echo "manual_dispatch=${manual_dispatch}" >> "${GITHUB_OUTPUT}"
           echo "packages=${packages}"
           echo "work_required=${work_required}"
           echo "force_base=${force_base}"
@@ -189,6 +193,7 @@ jobs:
         env:
           PACKAGE: debian-blockchain-base
           FORCE_BUILD: ${{ needs.select.outputs.force_base }}
+          MANUAL_DISPATCH: ${{ needs.select.outputs.manual_dispatch }}
         run: |
           set -euo pipefail
           platforms=$(sed -n 's/^platforms = \[\(.*\)\]/\1/p' "docker-${PACKAGE}/build.toml" | tr -d '"' | tr ',' ' ')
@@ -210,7 +215,7 @@ jobs:
           if [ "${partial}" = "true" ] && [ "${manifest_exists}" != "true" ]; then
             echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
             exit 1
-          elif [ "${manifest_exists}" = "true" ] && [ "${FORCE_BUILD}" = "true" ]; then
+          elif [ "${manifest_exists}" = "true" ] && [ "${FORCE_BUILD}" = "true" ] && [ "${MANUAL_DISPATCH}" != "true" ]; then
             echo "${PACKAGE} is affected but its tag already exists; bump package.version or package.build" >&2
             exit 1
           elif [ "${manifest_exists}" = "true" ]; then
@@ -227,15 +232,11 @@ jobs:
 
       - name: Set up QEMU
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        run: docker run --rm --privileged tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install all
 
       - name: Initialize Docker Buildx
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          name: bcn-ci
-          driver: docker-container
-          install: "true"
+        run: docker buildx create --name bcn-ci --driver docker-container --use 2>/dev/null || docker buildx use bcn-ci
 
       - name: Build Docker image
         if: steps.check-image.outputs.needs-build == 'true'
@@ -279,6 +280,7 @@ jobs:
         env:
           PACKAGE: debian-blockchain-build
           FORCE_BUILD: ${{ needs.select.outputs.force_build }}
+          MANUAL_DISPATCH: ${{ needs.select.outputs.manual_dispatch }}
         run: |
           set -euo pipefail
           platforms=$(sed -n 's/^platforms = \[\(.*\)\]/\1/p' "docker-${PACKAGE}/build.toml" | tr -d '"' | tr ',' ' ')
@@ -300,7 +302,7 @@ jobs:
           if [ "${partial}" = "true" ] && [ "${manifest_exists}" != "true" ]; then
             echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
             exit 1
-          elif [ "${manifest_exists}" = "true" ] && [ "${FORCE_BUILD}" = "true" ]; then
+          elif [ "${manifest_exists}" = "true" ] && [ "${FORCE_BUILD}" = "true" ] && [ "${MANUAL_DISPATCH}" != "true" ]; then
             echo "${PACKAGE} is affected but its tag already exists; bump package.version or package.build" >&2
             exit 1
           elif [ "${manifest_exists}" = "true" ]; then
@@ -317,15 +319,11 @@ jobs:
 
       - name: Set up QEMU
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        run: docker run --rm --privileged tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install all
 
       - name: Initialize Docker Buildx
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          name: bcn-ci
-          driver: docker-container
-          install: "true"
+        run: docker buildx create --name bcn-ci --driver docker-container --use 2>/dev/null || docker buildx use bcn-ci
 
       - name: Build Docker image
         if: steps.check-image.outputs.needs-build == 'true'
@@ -371,6 +369,7 @@ jobs:
         id: check-image
         env:
           PACKAGE: ${{ matrix.package }}
+          MANUAL_DISPATCH: ${{ needs.select.outputs.manual_dispatch }}
         run: |
           set -euo pipefail
           platforms=$(sed -n 's/^platforms = \[\(.*\)\]/\1/p' "docker-${PACKAGE}/build.toml" | tr -d '"' | tr ',' ' ')
@@ -385,6 +384,9 @@ jobs:
           if [ "${partial}" = "true" ] && [ "${manifest_exists}" != "true" ]; then
             echo "A partial ${PACKAGE} publication exists; refusing to overwrite it" >&2
             exit 1
+          elif [ "${manifest_exists}" = "true" ] && [ "${MANUAL_DISPATCH}" = "true" ]; then
+            echo "needs-build=false" >> "${GITHUB_OUTPUT}"
+            echo "${PACKAGE} already exists; skipping manual rebuild"
           elif [ "${manifest_exists}" = "true" ]; then
             echo "${PACKAGE} is affected but its tag already exists; bump package.version or package.build" >&2
             exit 1
@@ -399,15 +401,11 @@ jobs:
 
       - name: Set up QEMU
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        run: docker run --rm --privileged tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install all
 
       - name: Initialize Docker Buildx
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          name: bcn-ci
-          driver: docker-container
-          install: "true"
+        run: docker buildx create --name bcn-ci --driver docker-container --use 2>/dev/null || docker buildx use bcn-ci
 
       - name: Build and publish Docker image
         if: steps.check-image.outputs.needs-build == 'true'

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -232,11 +232,17 @@ jobs:
 
       - name: Set up QEMU
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        run: docker run --rm --privileged tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install all
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          image: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: all
 
       - name: Initialize Docker Buildx
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        run: docker buildx create --name bcn-ci --driver docker-container --use 2>/dev/null || docker buildx use bcn-ci
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          driver: docker-container
+          name: bcn-ci-${{ github.run_id }}-base
 
       - name: Build Docker image
         if: steps.check-image.outputs.needs-build == 'true'
@@ -319,11 +325,17 @@ jobs:
 
       - name: Set up QEMU
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        run: docker run --rm --privileged tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install all
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          image: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: all
 
       - name: Initialize Docker Buildx
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        run: docker buildx create --name bcn-ci --driver docker-container --use 2>/dev/null || docker buildx use bcn-ci
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          driver: docker-container
+          name: bcn-ci-${{ github.run_id }}-build
 
       - name: Build Docker image
         if: steps.check-image.outputs.needs-build == 'true'
@@ -401,11 +413,17 @@ jobs:
 
       - name: Set up QEMU
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        run: docker run --rm --privileged tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install all
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          image: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: all
 
       - name: Initialize Docker Buildx
         if: steps.check-image.outputs.needs-build == 'true' && matrix.config.writer
-        run: docker buildx create --name bcn-ci --driver docker-container --use 2>/dev/null || docker buildx use bcn-ci
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          driver: docker-container
+          name: bcn-ci-${{ github.run_id }}-${{ matrix.package }}
 
       - name: Build and publish Docker image
         if: steps.check-image.outputs.needs-build == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       pull-requests: read
     uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@eeb8a182174f3c97c370ecf3f1e3e4689ae22cfe # 2026.8.31
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'push' && 'github' || 'velnor') }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'schedule' && 'both' || 'velnor') }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -123,7 +123,7 @@ jobs:
       pull-requests: read
     uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@84a3d2c5f8f74a3054259ac494581b244bf61ee7 # 2026.8.31
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'push' && 'github' || 'velnor') }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'schedule' && 'both' || 'velnor') }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -145,7 +145,7 @@ jobs:
       pull-requests: read
     uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@4561d3dc3a410980b8a3858d42b88a34c5e757f4 # 2026.8.31
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'push' && 'github' || 'velnor') }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'schedule' && 'both' || 'velnor') }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]}]') }}
+        config: ${{ fromJSON(((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') || github.event_name == 'schedule') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]}]') }}
     runs-on: ${{ matrix.config.velnor_default_runner }}
     permissions:
       contents: read

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false,"dry_run":"full"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"}]') }}
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false,"dry_run":"full"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"}]') }}
     runs-on: ${{ matrix.config.velnor_default_runner }}
     env:
       # Plain (non-secret) Renovate settings. Secret-bearing strings embedded

--- a/BUILD_SYSTEM.md
+++ b/BUILD_SYSTEM.md
@@ -151,6 +151,21 @@ The build script performs the following steps:
    - Creates a multi-platform manifest tagged as `<repository>:<full-version>`
    - Pushes the manifest to the registry
 
+## CI/CD
+
+`.github/workflows/build-publish.yml` publishes on pushes to `main` and
+supports manual dispatch. It selects changed
+`docker-<package>/` directories, then starts one matrix job per affected
+package. Changes to shared Docker build tooling trigger all packages. The
+Debian base and build images run first when needed. Complete existing manifest
+tags are never overwritten; partial publications fail for manual recovery.
+
+Writer jobs log in to Docker Hub with `DOCKERHUB_USERNAME` and
+`DOCKERHUB_TOKEN`, then run `mise run build <package>`. The builder publishes
+platform tags (`<full-version>-<platform>`) and the final manifest tag
+(`<full-version>`). A read-only GitHub lane is available for parity runs and
+uses `build-dry`, so it never publishes.
+
 ## Build Argument Naming Convention
 
 ### Automatic Version Arguments

--- a/BUILD_SYSTEM.md
+++ b/BUILD_SYSTEM.md
@@ -157,8 +157,10 @@ The build script performs the following steps:
 supports manual dispatch. It selects changed
 `docker-<package>/` directories, then starts one matrix job per affected
 package. Changes to shared Docker build tooling trigger all packages. The
-Debian base and build images run first when needed. Complete existing manifest
-tags are never overwritten; partial publications fail for manual recovery.
+Debian base and build images run first when needed. An affected image whose
+current tag already exists fails closed and requires a `package.version` or
+`package.build` bump; complete existing tags are never overwritten. Partial
+publications also fail for manual recovery.
 
 Writer jobs log in to Docker Hub with `DOCKERHUB_USERNAME` and
 `DOCKERHUB_TOKEN`, then run `mise run build <package>`. The builder publishes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -588,7 +588,7 @@ services:
       - ${OMNI_ROOT_DIR:-~}/omni:/data
 
   tron-java:
-    image: chainargos/tron-java:4.8.1-1@sha256:7c48e82a4edbf74dc12ce5e020f56dd631c851f914a303408567640d14736381
+    image: chainargos/tron-java:4.8.2.1-1@sha256:841e5eb3de927fb5408e587665cf4cd649427e3afebb5b784a71123e2640930f
     container_name: tron-java
     restart: unless-stopped
     stop_grace_period: 15m

--- a/docker-tron-java/README.md
+++ b/docker-tron-java/README.md
@@ -5,3 +5,10 @@
 ```bash
 rust-script sync-config.rs
 ```
+
+## Runtime defaults
+
+The packaged mainnet configuration uses RocksDB. Prometheus metrics and event
+subscriptions are disabled by default, and legacy InfluxDB settings are not
+included. JSON-RPC request, response, batch, and filter limits follow the
+upstream defaults.

--- a/docker-tron-java/build.toml
+++ b/docker-tron-java/build.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tron-java"
-version = "4.8.1.1"
+version = "4.8.2.1"
 build = "1"
 
 [docker]

--- a/docker-tron-java/config/main_net_config.conf
+++ b/docker-tron-java/config/main_net_config.conf
@@ -1,70 +1,26 @@
 net {
-  # Type can be 'mainnet' or 'testnet', refers to address type.
-  # Hex address of 'mainnet' begin with 0x41, and 'testnet' begin with 0xa0.
-  # Note: 'testnet' is not related to TRON network Nile, Shasta or private net
-  type = mainnet
 }
 
 storage {
-  # Directory for storing persistent data
-  db.engine = "ROCKSDB",  // deprecated for arm, because arm only support  "ROCKSDB".
+  db.engine = "ROCKSDB",
   db.sync = false,
   db.directory = "database",
 
   # Whether to write transaction result in transactionRetStore
   transHistory.switch = "on",
 
-  # setting can improve leveldb performance .... start, deprecated for arm
-  # node: if this will increase process fds,you may be check your ulimit if 'too many open files' error occurs
-  # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
-  # if you find block sync has lower performance, you can try this settings
-  # default = {
-  #  maxOpenFiles = 100
-  # }
-  # defaultM = {
-  #  maxOpenFiles = 500
-  # }
-  # defaultL = {
-  #  maxOpenFiles = 1000
-  # }
-  # setting can improve leveldb performance .... end, deprecated for arm
-
-  # You can customize the configuration for each database. Otherwise, the database settings will use
-  # their defaults, and data will be stored in the "output-directory" or in the directory specified
-  # by the "-d" or "--output-directory" option. Attention: name is a required field that must be set!
-  # In this configuration, the name and path properties take effect for both LevelDB and RocksDB storage engines,
-  # while the additional properties (such as createIfMissing, paranoidChecks, compressionType, etc.) only take effect when using LevelDB.
+  # Per-database storage path overrides (name is required; see reference.conf for full property list).
   properties = [
-    #    {
-    #      name = "account",
-    #      path = "storage_directory_test",
-    #      createIfMissing = true, // deprecated for arm start
-    #      paranoidChecks = true,
-    #      verifyChecksums = true,
-    #      compressionType = 1,        // compressed with snappy
-    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    #      maxOpenFiles = 100 // deprecated for arm end
-    #    },
-    #    {
-    #      name = "account-index",
-    #      path = "storage_directory_test",
-    #      createIfMissing = true,
-    #      paranoidChecks = true,
-    #      verifyChecksums = true,
-    #      compressionType = 1,        // compressed with snappy
-    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    #      maxOpenFiles = 100
-    #    },
+  #   {
+  #     name = "account",
+  #     path = "storage_directory_test",
+  #     maxOpenFiles = 100
+  #   },
   ]
 
   needToUpdateAsset = true
 
-  # dbsettings is needed when using rocksdb as the storage implement (db.engine="ROCKSDB").
-  # we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
+  # RocksDB settings (only used when db.engine = "ROCKSDB"). See reference.conf for details.
   dbSettings = {
     levelNumber = 7
     # compactThreads = 32
@@ -79,24 +35,8 @@ storage {
 
   balance.history.lookup = false
 
-  # checkpoint.version = 2
-  # checkpoint.sync = true
-
-  # the estimated number of block transactions (default 1000, min 100, max 10000).
-  # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
-  # txCache.estimatedTransactions = 1000
-
-  # if true, transaction cache initialization will be faster. Default: false
+  # If true, transaction cache initialization will be faster. Default: false
   txCache.initOptimization = true
-
-  # The number of blocks flushed to db in each batch during node syncing. Default: 1
-  # snapshot.maxFlushCount = 1
-
-  # data root setting, for check data, currently, only reward-vi is used.
-  # merkleRoot = {
-  # reward-vi = 9debcb9924055500aaae98cdee10501c5c39d4daa75800a996f4bdda73dbccd8 // main-net, Sha256Hash, hexString
-  # }
-
 }
 
 node.discovery = {
@@ -104,24 +44,17 @@ node.discovery = {
   persist = true
 }
 
-# custom stop condition
-#node.shutdown = {
-#  BlockTime  = "54 59 08 * * ?" # if block header time in persistent db matched.
-#  BlockHeight = 33350800 # if block header height in persistent db matched.
-#  BlockCount = 12 # block sync count after node start.
-#}
+# Custom stop condition
+# node.shutdown = {
+#   BlockTime  = "54 59 08 * * ?" # if block header time in persistent db matched.
+#   BlockHeight = 33350800 # if block header height in persistent db matched.
+#   BlockCount = 12 # block sync count after node start.
+# }
 
 node.backup {
-  # udp listen port, each member should have the same configuration
   port = 10001
-
-  # my priority, each member should use different priority
   priority = 8
-
-  # time interval to send keepAlive message, each member should have the same configuration
   keepAliveInterval = 3000
-
-  # peer's ip list, can't contain mine
   members = [
     # "ip",
     # "ip"
@@ -134,25 +67,13 @@ crypto {
 }
 
 node.metrics = {
-  # prometheus metrics
   prometheus {
     enable = false
     port = 9527
   }
-
-  # influxdb metrics
-  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
-  influxdb {
-    ip = ""
-    port = 8086
-    database = ""
-    metricsReportInterval = 10
-  }
 }
 
 node {
-  # trust node for solidity node
-  # trustNode = "ip:port"
   trustNode = "127.0.0.1:50051"
 
   # expose extension api to public or not
@@ -160,37 +81,14 @@ node {
 
   listen.port = 18888
 
-  connection.timeout = 2
-
   fetchBlock.timeout = 200
-  # syncFetchBatchNum = 2000
-
-  # Number of validate sign thread, default availableProcessors
-  # validateSignThreadNum = 16
 
   maxConnections = 30
-
   minConnections = 8
-
   minActiveConnections = 3
-
   maxConnectionsWithSameIp = 2
-
   maxHttpConnectNumber = 50
-
   minParticipationRate = 15
-
-  # allowShieldedTransactionApi = true
-
-  # openPrintLog = true
-
-  # If set to true, SR packs transactions into a block in descending order of fee; otherwise, it packs
-  # them based on their receive timestamp. Default: false
-  # openTransactionSort = false
-
-  # The threshold for the number of broadcast transactions received from each peer every second,
-  # transactions exceeding this threshold will be discarded
-  # maxTps = 1000
 
   isOpenFullTcpDisconnect = false
   inactiveThreshold = 600 //seconds
@@ -201,14 +99,12 @@ node {
 
   active = [
     # Active establish connection in any case
-    # Sample entries:
     # "ip:port",
     # "ip:port"
   ]
 
   passive = [
     # Passive accept connection in any case
-    # Sample entries:
     # "ip:port",
     # "ip:port"
   ]
@@ -235,207 +131,53 @@ node {
     PBFTEnable = true
     PBFTPort = 50071
 
-    # Number of gRPC thread, default availableProcessors / 2
-    # thread = 16
-
-    # The maximum number of concurrent calls permitted for each incoming connection
-    # maxConcurrentCallsPerConnection =
-
-    # The HTTP/2 flow control window, default 1MB
-    # flowControlWindow =
-
-    # Connection being idle for longer than which will be gracefully terminated
     maxConnectionIdleInMillis = 60000
-
-    # Connection lasting longer than which will be gracefully terminated
-    # maxConnectionAgeInMillis =
-
-    # The maximum message size allowed to be received on the server, default 4MB
-    # maxMessageSize =
-
-    # The maximum size of header list allowed to be received, default 8192
-    # maxHeaderListSize =
-
-    # The number of RST_STREAM frames allowed to be sent per connection per period for grpc, by default there is no limit.
-    # maxRstStream =
-
-    # The number of seconds per period for grpc
-    # secondsPerWindow =
-
-    # Transactions can only be broadcast if the number of effective connections is reached.
     minEffectiveConnection = 1
 
-    # The switch of the reflection service, effective for all gRPC services, used for grpcurl tool. Default: false
+    # The switch of the reflection service for grpcurl tool. Default: false
     reflectionService = false
   }
 
-  # number of solidity thread in the FullNode.
-  # If accessing solidity rpc and http interface timeout, could increase the number of threads,
-  # The default value is the number of cpu cores of the machine.
-  # solidity.threads = 8
-
-  # Limits the maximum percentage (default 75%) of producing block interval
-  # to provide sufficient time to perform other operations e.g. broadcast block
-  # blockProducedTimeOut = 75
-
-  # Limits the maximum number (default 700) of transaction from network layer
-  # netMaxTrxPerSecond = 700
-
-  # Whether to enable the node detection function. Default: false
-  # nodeDetectEnable = false
-
-  # use your ipv6 address for node discovery and tcp connection. Default: false
-  # enableIpv6 = false
-
-  # if your node's highest block num is below than all your pees', try to acquire new connection. Default: false
-  # effectiveCheckEnable = false
-
-  # Dynamic loading configuration function, disabled by default
   dynamicConfig = {
     # enable = false
-    # checkInterval = 600 // Check interval of Configuration file's change, default is 600 seconds
+    # checkInterval = 600
   }
 
-  # Whether to continue broadcast transactions after at least maxUnsolidifiedBlocks are not solidified. Default: false
-  # unsolidifiedBlockCheck = false
-  # maxUnsolidifiedBlocks = 54
-
   dns {
-    # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
     treeUrls = [
       #"tree://AKMQMNAJJBL73LXWPXDI4I5ZWWIZ4AWO34DWQ636QOBBXNFXH3LQS@main.trondisco.net",
     ]
-
-    # enable or disable dns publish. Default: false
-    # publish = false
-
-    # dns domain to publish nodes, required if publish is true
-    # dnsDomain = "nodes1.example.org"
-
-    # dns private key used to publish, required if publish is true, hex string of length 64
-    # dnsPrivate = "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
-
-    # known dns urls to publish if publish is true, url format tree://{pubkey}@{domain}, default empty
-    # knownUrls = [
-    #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes2.example.org",
-    # ]
-
-    # staticNodes = [
-    # static nodes to published on dns
-    # Sample entries:
-    # "ip:port",
-    # "ip:port"
-    # ]
-
-    # merge several nodes into a leaf of tree, should be 1~5
-    # maxMergeSize = 5
-
-    # only nodes change percent is bigger then the threshold, we update data on dns
-    # changeThreshold = 0.1
-
-    # dns server to publish, required if publish is true, only aws or aliyun is support
-    # serverType = "aws"
-
-    # access key id of aws or aliyun api, required if publish is true, string
-    # accessKeyId = "your-key-id"
-
-    # access key secret of aws or aliyun api, required if publish is true, string
-    # accessKeySecret = "your-key-secret"
-
-    # if publish is true and serverType is aliyun, it's endpoint of aws dns server, string
-    # aliyunDnsEndpoint = "alidns.aliyuncs.com"
-
-    # if publish is true and serverType is aws, it's region of aws api, such as "eu-south-1", string
-    # awsRegion = "us-east-1"
-
-    # if publish is true and server-type is aws, it's host zone id of aws's domain, string
-    # awsHostZoneId = "your-host-zone-id"
   }
 
-  # open the history query APIs(http&GRPC) when node is a lite FullNode,
-  # like {getBlockByNum, getBlockByID, getTransactionByID...}. Default: false.
-  # note: above APIs may return null even if blocks and transactions actually are on the blockchain
-  # when opening on a lite FullNode. only open it if the consequences being clearly known
-  # openHistoryQueryWhenLiteFN = false
-
   jsonrpc {
-    # Note: Before release_4.8.1, if you turn on jsonrpc and run it for a while and then turn it off,
-    # you will not be able to get the data from eth_getLogs for that period of time. Default: false
     httpFullNodeEnable = true
     httpFullNodePort = 28545
     httpSolidityEnable = true
     httpSolidityPort = 28555
-    # httpPBFTEnable = false
-    # httpPBFTPort = 8565
 
-    # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
-    # should be > 0, otherwise means no limit.
     maxBlockRange = 5000
-
-    # The maximum number of allowed topics within a topic criteria, default value is 1000,
-    # should be > 0, otherwise means no limit.
+    maxAddressSize = 1000
     maxSubTopics = 1000
-    # Allowed maximum number for blockFilter
     maxBlockFilterNum = 50000
+    maxBatchSize = 100
+    maxResponseSize = 26214400
+    maxLogFilterNum = 20000
+    maxMessageSize = 4194304
   }
 
-  # Disabled api list, it will work for http, rpc and pbft, both FullNode and SolidityNode,
-  # but not jsonrpc. The setting is case insensitive, GetNowBlock2 is equal to getnowblock2
   disabledApi = [
     #  "getaccount",
     #  "getnowblock2"
   ]
-
 }
 
 ## rate limiter config
 rate.limiter = {
-  # Every api could only set a specific rate limit strategy. Three blocking strategy are supported:
-  # GlobalPreemptibleAdapter: The number of preemptible resource or maximum concurrent requests globally.
-  # QpsRateLimiterAdapter: qps is the average request count in one second supported by the server, it could be a Double or a Integer.
-  # IPQPSRateLimiterAdapter: similar to the QpsRateLimiterAdapter, qps could be a Double or a Integer.
-  # If not set, QpsRateLimiterAdapter with qps=1000 is the default strategy.
-  #
-  # Sample entries:
-  #
+  # See reference.conf for available strategies (GlobalPreemptibleAdapter, QpsRateLimiterAdapter, IPQPSRateLimiterAdapter).
   http = [
-    #  {
-    #    component = "GetNowBlockServlet",
-    #    strategy = "GlobalPreemptibleAdapter",
-    #    paramString = "permit=1"
-    #  },
-
-    #  {
-    #    component = "GetAccountServlet",
-    #    strategy = "IPQPSRateLimiterAdapter",
-    #    paramString = "qps=1"
-    #  },
-
-    #  {
-    #    component = "ListWitnessesServlet",
-    #    strategy = "QpsRateLimiterAdapter",
-    #    paramString = "qps=1"
-    #  }
   ],
 
   rpc = [
-    #  {
-    #    component = "protocol.Wallet/GetBlockByLatestNum2",
-    #    strategy = "GlobalPreemptibleAdapter",
-    #    paramString = "permit=1"
-    #  },
-
-    #  {
-    #    component = "protocol.Wallet/GetAccount",
-    #    strategy = "IPQPSRateLimiterAdapter",
-    #    paramString = "qps=1"
-    #  },
-
-    #  {
-    #    component = "protocol.Wallet/ListWitnesses",
-    #    strategy = "QpsRateLimiterAdapter",
-    #    paramString = "qps=1"
-    #  },
   ]
 
   p2p = {
@@ -448,6 +190,8 @@ rate.limiter = {
   global.qps = 50000
   # IP-based global qps, default 10000
   global.ip.qps = 10000
+  # If true, API rate limiters reject immediately on overload (non-blocking). Default: false
+  apiNonBlocking = false
 }
 
 
@@ -455,11 +199,6 @@ rate.limiter = {
 seed.node = {
   # List of the seed nodes
   # Seed nodes are stable full nodes
-  # example:
-  # ip.list = [
-  #   "ip:port",
-  #   "ip:port"
-  # ]
   ip.list = [
     "3.225.171.164:18888",
     "52.8.46.215:18888",
@@ -662,10 +401,10 @@ genesis.block = {
   parentHash = "0xe58f33f9baf9305dc6f82b9f1934ea8f0ade2defb951258d50167028c780351f"
 }
 
-# Optional. The default is empty. It is used when the witness account has set the witnessPermission.
-# When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
-# and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
-# When it is empty,the localwitness is configured with the private key of the witness account.
+# Optional. Used when the witness account has set witnessPermission.
+# localWitnessAccountAddress is the witness account address;
+# localwitness is configured with the private key of the witnessPermissionAddress.
+# When empty, localwitness is the private key of the witness account itself.
 # localWitnessAccountAddress =
 
 localwitness = [
@@ -679,14 +418,10 @@ block = {
   needSyncCheck = true
   maintenanceTimeInterval = 21600000 // 6 hours: 21600000(ms)
   proposalExpireTime = 259200000 // default value: 3 days: 259200000(ms), Note: this value is controlled by committee proposal
-  # checkFrozenTime = 1 // for test only
 }
 
 # Transaction reference block, default is "solid", configure to "head" may cause TaPos error
 trx.reference.block = "solid" // "head" or "solid"
-
-# This property sets the number of milliseconds after the creation of the transaction that is expired, default value is  60000.
-# trx.expiration.timeInMilliseconds = 60000
 
 vm = {
   supportConstant = false
@@ -694,93 +429,30 @@ vm = {
   minTimeRatio = 0.0
   maxTimeRatio = 5.0
   saveInternalTx = false
-  # lruCacheSize = 500
-  # vmTrace = false
-
-  # Indicates whether the node stores featured internal transactions, such as freeze, vote and so on. Default: false.
-  # saveFeaturedInternalTx = false
-
-  # Indicates whether the node stores the details of the internal transactions generated by the CANCELALLUNFREEZEV2 opcode,
-  # such as bandwidth/energy/tronpower cancel amount. Default: false.
-  # saveCancelAllUnfreezeV2Details = false
-
-  # In rare cases, transactions that will be within the specified maximum execution time (default 10(ms)) are re-executed and packaged
-  # longRunningTime = 10
-
-  # Indicates whether the node support estimate energy API. Default: false.
-  # estimateEnergy = false
-
-  # Indicates the max retry time for executing transaction in estimating energy. Default 3.
-  # estimateEnergyMaxRetry = 3
 }
 
 # These parameters are designed for private chain testing only and cannot be freely switched on or off in production systems.
+# In production, they are controlled by on-chain committee proposals.
 committee = {
   allowCreationOfContracts = 0  //mainnet:0 (reset by committee),test:1
   allowAdaptiveEnergy = 0  //mainnet:0 (reset by committee),test:1
-  # allowCreationOfContracts = 0
-  # allowMultiSign = 0
-  # allowAdaptiveEnergy = 0
-  # allowDelegateResource = 0
-  # allowSameTokenName = 0
-  # allowTvmTransferTrc10 = 0
-  # allowTvmConstantinople = 0
-  # allowTvmSolidity059 = 0
-  # forbidTransferToContract = 0
-  # allowShieldedTRC20Transaction = 0
-  # allowTvmIstanbul = 0
-  # allowMarketTransaction = 0
-  # allowProtoFilterNum = 0
-  # allowAccountStateRoot = 0
-  # changedDelegation = 0
-  # allowPBFT = 0
-  # pBFTExpireNum = 0
-  # allowTransactionFeePool = 0
-  # allowBlackHoleOptimization = 0
-  # allowNewResourceModel = 0
-  # allowReceiptsMerkleRoot = 0
-  # allowTvmFreeze = 0
-  # allowTvmVote = 0
-  # unfreezeDelayDays = 0
-  # allowTvmLondon = 0
-  # allowTvmCompatibleEvm = 0
-  # allowNewRewardAlgorithm = 0
-  # allowAccountAssetOptimization = 0
-  # allowAssetOptimization = 0
-  # allowNewReward = 0
-  # memoFee = 0
-  # allowDelegateOptimization = 0
-  # allowDynamicEnergy = 0
-  # dynamicEnergyThreshold = 0
-  # dynamicEnergyMaxFactor = 0
-  # allowTvmShangHai = 0
-  # allowOldRewardOpt = 0
-  # allowEnergyAdjustment = 0
-  # allowStrictMath = 0
-  # allowTvmCancun = 0
-  # allowTvmBlob = 0
-  # consensusLogicOptimization = 0
-  # allowOptimizedReturnValueOfChainId = 0
 }
 
 event.subscribe = {
+  enable = false // enable event subscribe, replaces deprecated CLI flag --es
   native = {
     useNativeQueue = true // if true, use native message queue, else use event plugin.
     bindport = 5555 // bind port
     sendqueuelength = 1000 //max length of send queue
   }
   version = 0
-  # Specify the starting block number to sync historical events. This is only applicable when version = 1.
+  # Specify the starting block number to sync historical events. Only applicable when version = 1.
   # After performing a full event sync, set this value to 0 or a negative number.
   # startSyncBlockNum = 1
 
   path = "" // absolute path of plugin
-  server = "" // target server address to receive event triggers
-  # dbname|username|password, if you want to create indexes for collections when the collections
-  # are not exist, you can add version and set it to 2, as dbname|username|password|version
-  # if you use version 2 and one collection not exists, it will create index automaticaly;
-  # if you use version 2 and one collection exists, it will not create index, you must create index manually;
-  dbconfig = ""
+  server = "" // target server address to receive event triggers, "ip:port"
+  dbconfig = "" // dbname|username|password (append |2 to auto-create indexes on missing collections)
   contractParse = true
   topics = [
     {
@@ -809,7 +481,7 @@ event.subscribe = {
     },
     {
       triggerName = "solidity" // solidity block trigger(just include solidity block number and timestamp), the value can't be modified
-      enable = true            // Default: true
+      enable = false
       topic = "solidity"
     },
     {


### PR DESCRIPTION
Restores the separate Docker build/publish workflow that was folded into generated ci.yml in 66e8bd6.\n\n- Selects affected docker-* packages from each main push.\n- Runs one matrix job per affected package.\n- Restores Velnor writer, GitHub writer, and read-only parity lanes.\n- Publishes Docker Hub platform tags and manifests with the existing builder/cache.\n- Builds shared Debian base/build images first when needed.\n- Skips complete tags and refuses partial publications.\n\nValidation:\n- workflow YAML parsed\n- selector shell syntax and affected-package cases checked\n- mise run build-dry tron-java\n- cargo check --workspace --all-targets --locked