### PR TITLE
fix(ci): route push events to the GitHub lane again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       pull-requests: read
     uses: jackin-project/velnor-actions/.github/workflows/ci-code.yml@eeb8a182174f3c97c370ecf3f1e3e4689ae22cfe # 2026.8.31
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'schedule' && 'both' || 'velnor') }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'push' && 'github' || (github.event_name == 'schedule' && 'both' || 'velnor')) }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -123,7 +123,7 @@ jobs:
       pull-requests: read
     uses: tailrocks/velnor-actions/.github/workflows/ci-code.yml@84a3d2c5f8f74a3054259ac494581b244bf61ee7 # 2026.8.31
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'schedule' && 'both' || 'velnor') }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'push' && 'github' || (github.event_name == 'schedule' && 'both' || 'velnor')) }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -145,7 +145,7 @@ jobs:
       pull-requests: read
     uses: ChainArgos/velnor-actions/.github/workflows/ci-code.yml@4561d3dc3a410980b8a3858d42b88a34c5e757f4 # 2026.8.31
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'schedule' && 'both' || 'velnor') }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'push' && 'github' || (github.event_name == 'schedule' && 'both' || 'velnor')) }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJSON(((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') || github.event_name == 'schedule') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]}]') }}
+        config: ${{ fromJSON(((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') || github.event_name == 'schedule') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"]}]') }}
     runs-on: ${{ matrix.config.velnor_default_runner }}
     permissions:
       contents: read

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false,"dry_run":"full"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"}]') }}
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"},{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":false,"dry_run":"full"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || (github.event_name == 'push') && '[{"lane":"GitHub","velnor_default_runner":"ubuntu-26.04","writer":true,"dry_run":"false"}]' || '[{"lane":"Velnor","velnor_default_runner":["self-hosted","velnor-target-mvp"],"writer":true,"dry_run":"false"}]') }}
     runs-on: ${{ matrix.config.velnor_default_runner }}
     env:
       # Plain (non-secret) Renovate settings. Secret-bearing strings embedded


### PR DESCRIPTION
## Why

d63be73 rewrote `ci.yml`/`renovate.yml` and dropped the canonical push-to-GitHub lane routing. Post-merge pushes to main then dispatched to velnor-trusted, the fleet rejected them (`merged_push_occupancy`), and both **CI** and **Renovate** went red on main (runs 32831337298, 32831336364).

## What

- Caller `lane:` expressions: push -> `github` (keeps schedule -> `both` added by d63be73).
- `ci-required` matrix: push -> GitHub lane entry.
- Renovate matrix: push -> GitHub lane (writer, no dry-run).

Matches the canonical velnor-actions generator routing ("Velnor-default lane, push routes to GitHub").