### PR TITLE
chore(mise): use named arg syntax with usage field for task arguments

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,31 +8,41 @@ lockfile = true
 
 [tasks.build]
 description = "Build a Docker image"
-run = "./docker-build.rs $1"
+usage = 'arg "<package>" help="Package name to build"'
+run = "./docker-build.rs ${usage_package:?}"
 
 [tasks."build-dry"]
 description = "Build a Docker image (dry run)"
-run = "./docker-build.rs $1 --dry-run"
+usage = 'arg "<package>" help="Package name to build"'
+run = "./docker-build.rs ${usage_package:?} --dry-run"
 
 [tasks.exists]
 description = "Check if Docker image exists on Docker Hub"
-run = 'rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs $1'
+usage = 'arg "<package>" help="Package name"'
+run = 'rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs ${usage_package:?}'
 
 [tasks."exists-verbose"]
 description = "Check if Docker image exists (verbose)"
-run = 'rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs $1 --verbose'
+usage = 'arg "<package>" help="Package name"'
+run = 'rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs ${usage_package:?} --verbose'
 
 [tasks."exists-platform"]
 description = "Check if platform-specific Docker image exists"
-run = 'rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs $1 --platform $2'
+usage = '''
+arg "<package>" help="Package name"
+arg "<platform>" help="Platform (e.g. amd64, arm64)"
+'''
+run = 'rust-script --pkg-path "${RUST_SCRIPT_DOCKER_EXISTS_PKG_PATH:-$HOME/.cache/rust-script/docker-exists}" ./docker-exists.rs ${usage_package:?} --platform ${usage_platform:?}'
 
 [tasks.restart]
 description = "Restart a container with log following"
-run = "./containerctl.rs restart $1 -f"
+usage = 'arg "<container>" help="Container name"'
+run = "./containerctl.rs restart ${usage_container:?} -f"
 
 [tasks.stop]
 description = "Stop a container"
-run = "./containerctl.rs stop $1"
+usage = 'arg "<container>" help="Container name"'
+run = "./containerctl.rs stop ${usage_container:?}"
 
 [tasks.ci]
 description = "Check the Rust automation workspace"


### PR DESCRIPTION
## Summary

- Replace positional `$1`/`$2` in all parameterized mise task `run` scripts with named `${usage_name:?}` env vars
- Add `usage = 'arg "<name>"'` (multiline for the two-arg `exists-platform` task) to each parameterized task
- Resurrects closed-unmerged #587, adapted to current main: the `exists`/`exists-verbose`/`exists-platform` tasks now call `docker-exists.rs` via `rust-script --pkg-path`, so the named args were wired into those invocations instead

## Why

Positional `$1` expands to an empty string when the argument is omitted, producing confusing downstream failures. Named args fail fast: `mise ERROR Missing required arg: <package>`.

## Test plan

- [x] Verified against mise 2026.8.12 (local): `mise run stop` errors with "Missing required arg: <container>"
- [x] `mise run exists-platform geth` errors "Missing required arg: <platform>"
- [x] `mise run build-dry geth` resolves the named arg correctly and starts the geth dry-run build
- [ ] CI `build-publish` workflow passes (calls `mise run build <package>` positionally — unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
